### PR TITLE
FEAT: add kiro support for macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start start-prod stop logs clean build dev-backend dev-frontend setup check test-shell lint-backend .env
+.PHONY: start start-prod stop logs clean build dev-backend dev-frontend setup check test-shell lint-backend .env kiro-login
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 APP_NAME    := kronn
@@ -76,13 +76,13 @@ RESET  := \033[0m
 ## Generate docker-compose.override.yml for extra repo dirs (KRONN_EXTRA_REPOS)
 .PHONY: _gen-override
 _gen-override:
-	@KRONN_EXTRA_REPOS=$$(sed -n 's/^KRONN_EXTRA_REPOS=//p' .env | tail -n 1); \
-	if [ -n "$$KRONN_EXTRA_REPOS" ]; then \
+	@extra_repos=$$(sed -n 's/^KRONN_EXTRA_REPOS=//p' .env | tail -n 1); \
+	if [ -n "$$extra_repos" ]; then \
 		echo "# Auto-generated — extra rw mounts from KRONN_EXTRA_REPOS" > docker-compose.override.yml; \
 		echo "services:" >> docker-compose.override.yml; \
 		echo "  backend:" >> docker-compose.override.yml; \
 		echo "    volumes:" >> docker-compose.override.yml; \
-		IFS=':'; for dir in $$KRONN_EXTRA_REPOS; do \
+		IFS=':'; for dir in $$extra_repos; do \
 			rel=$${dir#$$HOME/}; \
 			echo "      - $$dir:/host-home/$$rel:rw" >> docker-compose.override.yml; \
 			echo "$(CYAN)  Extra rw mount: $$dir$(RESET)"; \
@@ -125,6 +125,11 @@ stop:
 ## Tail logs
 logs:
 	@$(DOCKER_COMP) logs -f
+
+## Login to Kiro from the backend container (headless-safe OAuth device flow)
+kiro-login: .env _gen-override
+	@echo "$(CYAN)▸ Kiro login (device flow)...$(RESET)"
+	@$(DOCKER_COMP) exec backend /bin/sh -lc 'set -e; PATH="$$HOME/.local/bin:$$PATH"; command -v kiro-cli >/dev/null 2>&1 || (command -v unzip >/dev/null 2>&1 || { echo "Missing unzip in backend image. Rebuild with make start."; exit 1; } ; echo "Installing kiro-cli in container..." ; curl -fsSL https://cli.kiro.dev/install | bash); kiro-cli login --use-device-flow'
 
 ## Clean everything
 clean:
@@ -204,6 +209,7 @@ help:
 	@echo "  make dev-backend    Rust hot reload"
 	@echo "  make dev-frontend   Vite dev server"
 	@echo "  make check          Verify prerequisites"
+	@echo "  make kiro-login     Kiro OAuth login (device flow in container)"
 	@echo "  make typegen        Sync Rust → TS types"
 	@echo "  make test-shell     Run shell tests (bats)"
 	@echo ""

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,7 +48,7 @@ RUN if getent group ${APP_GID} >/dev/null 2>&1; then \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates git curl nodejs npm python3 python3-pip \
-    make gh openssh-client \
+    make gh openssh-client unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install glab (GitLab CLI) for MR creation

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -41,4 +41,20 @@ if [ -d "$UV_TOOLS" ]; then
   done
 fi
 
+# On macOS hosts, never rely on host-mounted kiro-cli (Darwin binary).
+# Ensure a Linux kiro-cli is present in the container.
+PATH="${HOME}/.local/bin:${PATH}"
+if [ "${KRONN_HOST_OS:-}" = "macOS" ]; then
+  if ! command -v kiro-cli >/dev/null 2>&1; then
+    echo "[entrypoint] macOS host detected: installing Linux kiro-cli..."
+    if command -v unzip >/dev/null 2>&1; then
+      if ! curl -fsSL https://cli.kiro.dev/install | bash; then
+        echo "[entrypoint] warning: kiro-cli install failed (Kiro unavailable until fixed)."
+      fi
+    else
+      echo "[entrypoint] warning: unzip missing, cannot install kiro-cli."
+    fi
+  fi
+fi
+
 exec "$@"

--- a/backend/src/agents/mod.rs
+++ b/backend/src/agents/mod.rs
@@ -59,6 +59,13 @@ fn detect_host_label() -> String {
     "Linux".into()
 }
 
+fn host_is_macos() -> bool {
+    std::env::var("KRONN_HOST_OS")
+        .map(|os| os.eq_ignore_ascii_case("macos"))
+        .unwrap_or(false)
+        || detect_host_label() == "macOS"
+}
+
 /// Detect all known agents on the system
 pub async fn detect_all() -> Vec<AgentDetection> {
     let mut agents = Vec::new();
@@ -195,6 +202,11 @@ pub fn find_binary(name: &str) -> Option<BinaryLocation> {
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
                 if entry.file_name() == name {
+                    // On macOS hosts, host-mounted kiro-cli is a macOS binary
+                    // and cannot be executed from this Linux container.
+                    if name == "kiro-cli" && host_is_macos() {
+                        continue;
+                    }
                     return Some(BinaryLocation {
                         path: entry.path().to_string_lossy().to_string(),
                         host_managed: true,
@@ -284,5 +296,42 @@ pub async fn uninstall_agent(agent_type: &AgentType) -> Result<String> {
     } else {
         let err = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!("Uninstall failed: {}", err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn host_is_macos_detects_env_var() {
+        std::env::set_var("KRONN_HOST_OS", "macOS");
+        assert!(host_is_macos(), "Should detect macOS from KRONN_HOST_OS");
+        std::env::remove_var("KRONN_HOST_OS");
+    }
+
+    #[test]
+    #[serial]
+    fn host_is_macos_case_insensitive() {
+        std::env::set_var("KRONN_HOST_OS", "MACOS");
+        assert!(host_is_macos(), "Should be case-insensitive");
+        std::env::remove_var("KRONN_HOST_OS");
+    }
+
+    #[test]
+    #[serial]
+    fn host_is_not_macos_on_linux() {
+        std::env::set_var("KRONN_HOST_OS", "Linux");
+        assert!(!host_is_macos(), "Linux should not be detected as macOS");
+        std::env::remove_var("KRONN_HOST_OS");
+    }
+
+    #[test]
+    #[serial]
+    fn host_is_not_macos_when_unset() {
+        std::env::remove_var("KRONN_HOST_OS");
+        assert!(!host_is_macos(), "Should not be macOS when env is unset on Linux");
     }
 }

--- a/backend/src/agents/runner.rs
+++ b/backend/src/agents/runner.rs
@@ -312,6 +312,12 @@ pub async fn start_agent_with_config(config: AgentStartConfig<'_>) -> Result<Age
     // API key is optional — agents use their own local auth by default
     let api_key = get_api_key(env_key, config.tokens);
 
+    // On macOS hosts, host-mounted kiro-cli is not runnable in Linux containers.
+    // Ensure a Linux kiro-cli exists locally before spawning Kiro.
+    if matches!(config.agent_type, AgentType::Kiro) {
+        ensure_kiro_cli_available().await?;
+    }
+
     // Try direct binary first, then npx fallback
     let mut child = match try_spawn(binary, None, &args, &work_dir, env_key, api_key.as_deref()) {
         Ok(c) => c,
@@ -369,6 +375,49 @@ pub async fn start_agent_with_config(config: AgentStartConfig<'_>) -> Result<Age
     }
 
     Ok(AgentProcess { child, output_mode, work_dir, agent_type: config.agent_type.clone(), rx, stderr_capture, stderr_task: stderr_handle })
+}
+
+/// Ensure kiro-cli is available inside the container.
+/// Uses the official installer if missing.
+pub(crate) async fn ensure_kiro_cli_available() -> Result<(), String> {
+    if super::find_binary("kiro-cli").is_some() {
+        return Ok(());
+    }
+
+    tracing::info!("kiro-cli not found, installing Linux kiro-cli...");
+    let output = Command::new("sh")
+        .args([
+            "-c",
+            "command -v unzip >/dev/null 2>&1 || { echo 'Missing dependency: unzip' >&2; exit 127; }; \
+             curl -fsSL https://cli.kiro.dev/install | bash",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to launch Kiro installer: {e}"))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Kiro CLI install failed (exit {:?}): {}{}",
+            output.status.code(),
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!("\n{stdout}")
+            }
+        ));
+    }
+
+    if super::find_binary("kiro-cli").is_none() {
+        return Err(
+            "Kiro CLI installed but not found in PATH. Ensure /home/kronn/.local/bin is in PATH."
+                .into(),
+        );
+    }
+
+    Ok(())
 }
 
 /// Get the command configuration for an agent type.

--- a/backend/src/agents/runner_test.rs
+++ b/backend/src/agents/runner_test.rs
@@ -736,6 +736,18 @@ mod tests {
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
+    // ─── ensure_kiro_cli_available ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ensure_kiro_cli_skips_install_when_present() {
+        // kiro-cli is available on this machine (mounted from host)
+        // ensure_kiro_cli_available should return Ok immediately
+        let result = super::super::ensure_kiro_cli_available().await;
+        // On CI/dev where kiro-cli may not exist, this is allowed to fail
+        // The important thing is it doesn't panic
+        let _ = result;
+    }
+
     // ─── agent_command: Codex sandbox behavior ──────────────────────────────────
 
     #[test]

--- a/kronn
+++ b/kronn
@@ -64,6 +64,38 @@ agent = "${SELECTED_AGENT:-}"
 TOML
 }
 
+kiro_container_available() {
+    (cd "$KRONN_DIR" && docker compose exec -T backend /bin/sh -lc \
+        'PATH="$HOME/.local/bin:$PATH"; command -v kiro-cli >/dev/null 2>&1') >/dev/null 2>&1
+}
+
+kiro_container_authenticated() {
+    (cd "$KRONN_DIR" && docker compose exec -T backend /bin/sh -lc \
+        'PATH="$HOME/.local/bin:$PATH"; kiro-cli whoami --format json >/dev/null 2>&1') >/dev/null 2>&1
+}
+
+maybe_login_kiro() {
+    # Kiro container bootstrap is required on macOS hosts.
+    [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]] || return 0
+
+    if ! kiro_container_available; then
+        warn "kiro-cli n'est pas disponible dans le conteneur (installation en cours ou échouée)."
+        return 0
+    fi
+
+    info "Kiro détecté — vérification de l'authentification..."
+    if kiro_container_authenticated; then
+        success "Kiro déjà authentifié."
+        return 0
+    fi
+
+    warn "Kiro non authentifié dans le conteneur."
+    info "Lancement du login Kiro (device flow)..."
+    if ! (cd "$KRONN_DIR" && make kiro-login); then
+        warn "Login Kiro non finalisé. Tu peux relancer: make kiro-login"
+    fi
+}
+
 # ─── Commands ────────────────────────────────────────────────────────────────
 
 cmd_start() {
@@ -109,6 +141,7 @@ cmd_web() {
 
     info "Build & démarrage..."
     (cd "$KRONN_DIR" && make start)
+    maybe_login_kiro
 }
 
 cmd_repos() {


### PR DESCRIPTION
Kiro is a f**** binary. If you try to use it on macos the call will fail as linux is not MacOS. 

Now the Backend will install Kiro-cli directly to have its own version for linux.

./kronn start now provide a way to login to Kiro.

``
`
Kiro detecte — verification de l'authentification...
  ! Kiro non authentifie dans le container.
Lancement du login Kiro (device flow)...
▸ Kiro login (device flow)...
Installing kiro-cli in container...
Kiro CLI installer:

Downloading package...
✓ Downloaded and extracted
✓ Package installed successfully

🎉 Installation complete! Happy coding!

Next steps:
Use the command "kiro-cli" to get started!

✔ Select login method · Use with Pro license
✔ Enter Start URL · https://SSO.awsapps.com/start/
✔ Enter Region · eu-west-1

Confirm the following code in the browser
Code: GHCK-RPGD

Open this URL: https://SSO.awsapps.com/start/#/device?user_code=SECRETCODE
Device authorized

Logged in successfully
```