### PR TITLE
fix : stabilisation-1

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -212,6 +212,14 @@ jobs:
           fi
           echo "✓ No silent TOML unwrap_or_default"
 
+      - name: Lint — no unwrap() inside with_conn closures
+        run: |
+          # stab-1 — a panic inside a with_conn closure poisons the shared
+          # DB mutex (recovered since 0.8.11, but still one failed request).
+          # Baseline is ZERO in prod code: keep it that way.
+          python3 scripts/ci/test_lint_with_conn_unwrap.py
+          python3 scripts/ci/lint_with_conn_unwrap.py
+
       - name: cargo test
         run: cargo test
         env:

--- a/backend/scripts/ci/lint_with_conn_unwrap.py
+++ b/backend/scripts/ci/lint_with_conn_unwrap.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""CI anti-regression lint (stab-1): no `.unwrap()` inside `with_conn`
+closures in production code. A panic there poisons the shared DB mutex
+(recovered since 0.8.11, but still fails the request). Test modules
+(everything after the first `#[cfg(test)]` in a file) are exempt.
+Run from `backend/`: `python3 scripts/ci/lint_with_conn_unwrap.py`."""
+import pathlib
+import re
+import sys
+
+
+def _sanitize(text):
+    """Blank out string/char literals and comments (same length, newlines
+    kept so line numbers survive). Without this, a `)` inside a literal
+    closed the paren scan early and hid unwraps (Codex review); it also
+    prevents a literal ".unwrap()" in a string from false-positiving.
+    Handles: "…" with escapes, raw strings r"…" / r#"…"#…, char literals
+    (without eating lifetimes like 'a), // line and nested /* */ comments."""
+    out = list(text)
+    i, n = 0, len(text)
+
+    def blank(a, b):
+        for k in range(a, min(b, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    while i < n:
+        c = text[i]
+        two = text[i : i + 2]
+        if two == "//":
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            blank(i, j)
+            i = j
+        elif two == "/*":
+            depth, j = 1, i + 2
+            while j < n and depth:
+                if text[j : j + 2] == "/*":
+                    depth += 1
+                    j += 2
+                elif text[j : j + 2] == "*/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            blank(i, j)
+            i = j
+        elif c == '"' or (c == "r" and re.match(r'r#*"', text[i:])):
+            if c == '"':
+                j = i + 1
+                while j < n:
+                    if text[j] == "\\":
+                        j += 2
+                    elif text[j] == '"':
+                        j += 1
+                        break
+                    else:
+                        j += 1
+            else:
+                m = re.match(r'r(#*)"', text[i:])
+                closer = '"' + m.group(1)
+                j = text.find(closer, i + len(m.group(0)))
+                j = n if j == -1 else j + len(closer)
+            blank(i, j)
+            i = j
+        elif c == "'":
+            # Char literal ('x', '\n', '\u{…}') vs lifetime ('a) — a char
+            # literal always has a CLOSING quote within a few chars.
+            m = re.match(r"'(\\(?:u\{[0-9a-fA-F]{1,6}\}|.)|[^\\'])'", text[i:])
+            if m:
+                blank(i, i + m.end())
+                i += m.end()
+            else:
+                i += 1  # lifetime: skip the quote, keep the identifier
+        else:
+            i += 1
+    return "".join(out)
+
+
+def find_violations(text, path="<mem>"):
+    """`path:line` for every `.unwrap()` inside a `with_conn(...)` call.
+
+    Runs on SANITIZED text (strings/comments blanked) and scans to the
+    BALANCED closing paren with no length cap (Codex review, findings 2+3:
+    a 4k cap skipped long closures; literal parens broke the balance).
+    An unbalanced call is a hard error — loud beats a silent blind spot.
+    """
+    viol = []
+    prod = _sanitize(re.split(r"#\[cfg\(test\)\]", text)[0])
+    for m in re.finditer(r"with_conn(?:_blocking)?\s*\(", prod):
+        i, depth, end = m.end() - 1, 0, None
+        for j in range(i, len(prod)):
+            c = prod[j]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    end = j
+                    break
+        if end is None:
+            raise RuntimeError(
+                f"{path}: unbalanced parens after with_conn at offset {i} — lint cannot scan"
+            )
+        for um in re.finditer(r"\.unwrap\(\)", prod[i:end]):
+            line = prod[: i + um.start()].count("\n") + 1
+            viol.append(f"{path}:{line}")
+    return viol
+
+
+def main():
+    viol = []
+    for f in pathlib.Path("src").rglob("*.rs"):
+        viol.extend(find_violations(f.read_text(), str(f)))
+    if viol:
+        print("::error::unwrap() inside a with_conn closure panics the DB request — return an error instead:")
+        print("\n".join(viol))
+        sys.exit(1)
+    print("OK: no unwrap() inside with_conn closures")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/ci/test_lint_with_conn_unwrap.py
+++ b/backend/scripts/ci/test_lint_with_conn_unwrap.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fixture tests for the with_conn-unwrap CI lint (Codex review: the
+4k-char scan cap silently skipped long closures)."""
+import importlib.util
+import pathlib
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "lint_wcu", pathlib.Path(__file__).parent / "lint_with_conn_unwrap.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+class LintWithConnUnwrap(unittest.TestCase):
+    def test_flags_unwrap_placed_beyond_4k_chars(self):
+        # The exact blind spot: a closure body longer than the old cap.
+        filler = '            let _x = "' + "a" * 4200 + '";\n'
+        src = (
+            "fn f(db: &Db) {\n"
+            "    db.with_conn(move |conn| {\n"
+            + filler +
+            "        conn.query_row(q, [], |r| r.get(0)).unwrap();\n"
+            "        Ok(())\n"
+            "    });\n"
+            "}\n"
+        )
+        viol = _mod.find_violations(src, "long.rs")
+        self.assertEqual(len(viol), 1, "unwrap after 4k chars MUST be flagged")
+
+    def test_clean_closure_and_test_module_are_exempt(self):
+        src = (
+            "fn f(db: &Db) {\n"
+            "    db.with_conn(|conn| Ok(conn.count()?));\n"
+            "}\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn t(db: &Db) { db.with_conn(|c| Ok(c.count().unwrap())); }\n"
+            "}\n"
+        )
+        self.assertEqual(_mod.find_violations(src, "clean.rs"), [])
+
+    def test_unwrap_outside_the_closure_is_not_flagged(self):
+        src = (
+            "fn f(db: &Db) {\n"
+            "    let v = db.with_conn(|conn| Ok(conn.count()?));\n"
+            "    v.unwrap();\n"  # caller-side unwrap: out of this lint's scope
+            "}\n"
+        )
+        self.assertEqual(_mod.find_violations(src, "outside.rs"), [])
+
+    def test_literal_paren_in_string_does_not_hide_the_unwrap(self):
+        # Codex finding 3 — exact repro: a ")" string literal closed the
+        # scan artificially and the unwrap after it was invisible.
+        src = (
+            "fn f(db: &Db) {\n"
+            "    db.with_conn(|conn| {\n"
+            '        let text = ")";\n'
+            "        conn.query_row(q, [], |r| r.get(0)).unwrap();\n"
+            "        Ok(())\n"
+            "    });\n"
+            "}\n"
+        )
+        self.assertEqual(len(_mod.find_violations(src, "lit.rs")), 1)
+
+    def test_parens_in_comments_raw_strings_and_chars_are_ignored(self):
+        src = (
+            "fn f(db: &Db) {\n"
+            "    db.with_conn(|conn| {\n"
+            "        // closing ) in a comment\n"
+            "        /* nested /* )) */ still ) comment */\n"
+            '        let raw = r#"raw ) text"#;\n'
+            "        let ch = ')';\n"
+            "        let lt: &'static str = x;\n"
+            "        conn.count().unwrap();\n"
+            "        Ok(())\n"
+            "    });\n"
+            "}\n"
+        )
+        self.assertEqual(len(_mod.find_violations(src, "mix.rs")), 1,
+                         "the real unwrap is still flagged, literal parens ignored")
+
+    def test_unwrap_text_inside_a_string_is_not_flagged(self):
+        src = (
+            "fn f(db: &Db) {\n"
+            '    db.with_conn(|conn| { let s = ".unwrap()"; Ok(s.len()) });\n'
+            "}\n"
+        )
+        self.assertEqual(_mod.find_violations(src, "strunwrap.rs"), [])
+
+    def test_unbalanced_call_fails_loudly(self):
+        with self.assertRaises(RuntimeError):
+            _mod.find_violations("db.with_conn(|c| {", "broken.rs")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/scripts/disc-introspection-mcp.py
+++ b/backend/scripts/disc-introspection-mcp.py
@@ -32,6 +32,7 @@ already requiring it.
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -149,7 +150,11 @@ TOOLS = [
             "content, agent_type}, …]` to push a whole conversation "
             "history at once. Idempotent on (disc_id, source_msg_id) "
             "— re-pushing the same transcript does NOT duplicate.\n\n"
-            "Returns `{appended, skipped_as_duplicates, diverged}`. "
+            "Returns `{appended, skipped_as_duplicates, diverged, "
+            "last_sort_order}`. ALWAYS use `last_sort_order` as the "
+            "`since_sort_order` of your next `disc_wait_for_peer` — "
+            "NEVER estimate your position (+1 per post drifts under "
+            "concurrent posters and silently skips messages). "
             "`diverged=true` means the Kronn UI was edited after a "
             "previous import — warn the user before more updates."
         ),
@@ -2006,6 +2011,30 @@ def _http(method, path, body=None):
         raise RuntimeError(f"HTTP {e.code}: {body[:500]}")
 
 
+def _http_transport_retry(method, path, attempts=6, delays=(2, 4, 8, 12, 16)):
+    """`_http` with a BOUNDED retry on TRANSPORT failures only (connection
+    refused/reset, remote disconnect, socket timeout) — the signature of a
+    backend restart, e.g. `cargo watch` rebuilding for 30-60s. HTTP errors
+    (4xx/5xx) are application-level and never retried. Safe only for
+    idempotent calls: the caller re-sends the same request verbatim.
+    Total worst-case wait ≈ sum(delays) ≈ 42s + in-flight time."""
+    last_err = None
+    for i in range(attempts):
+        try:
+            return _http(method, path)
+        except RuntimeError:
+            raise  # HTTPError path from _http — application error, no retry
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError) as e:
+            last_err = e
+            if i + 1 < attempts:
+                time.sleep(delays[min(i, len(delays) - 1)])
+    raise RuntimeError(
+        f"backend unreachable after {attempts} attempts (~{sum(delays)}s — rebuild in "
+        f"progress?): {last_err}. Nothing is lost: messages persist in the DB — call "
+        "disc_wait_for_peer again with the SAME since_sort_order."
+    )
+
+
 def _http_text(method, path):
     """Variant of `_http` for endpoints that ship raw text (not JSON / not the
     `ApiResponse` envelope) — e.g. `/api/conventions/agents-md-format-v1`
@@ -2406,7 +2435,9 @@ def call_disc_wait_for_peer(args):
         params["exclude_agent_type"] = exclude
     qs = urllib.parse.urlencode(params)
     sep = "?" if qs else ""
-    result = _unwrap(_http("GET", f"/api/discussions/{disc_id}/wait{sep}{qs}"))
+    # Transport-level retry (bounded): a backend restart mid-poll must not
+    # surface as a tool error — the wait is idempotent on since_sort_order.
+    result = _unwrap(_http_transport_retry("GET", f"/api/discussions/{disc_id}/wait{sep}{qs}"))
     # A timed-out wait (no peer activity in the window) is NORMAL in an ongoing
     # collaboration — but literal agents (notably Codex) otherwise read the empty
     # result as "conversation over" and STOP after ~60s. Surface an explicit
@@ -2417,7 +2448,10 @@ def call_disc_wait_for_peer(args):
             "agent may still be thinking. Call disc_wait_for_peer AGAIN to keep "
             "waiting (pass latest_sort_order as since_sort_order). Do NOT stop "
             "or disc_leave() just because the wait timed out — only leave when "
-            "the task is done or the user explicitly says stop."
+            "the task is done or the user explicitly says stop. PACING: apply "
+            "the room's poll_policy (from disc_join/disc_meta) — consecutive "
+            "empty waits back off 30s,30s,1m,1m,2m,2m,4m,4m then cap at 8m; "
+            "reset to 30s as soon as a peer message arrives."
         )
     return result
 

--- a/backend/scripts/test_disc_introspection_mcp.py
+++ b/backend/scripts/test_disc_introspection_mcp.py
@@ -1335,6 +1335,57 @@ class DiscWaitForPeerTests(unittest.TestCase):
         self.addCleanup(self.env_patch.stop)
         self.mod = _load_module()
 
+    def test_transport_cut_is_retried_with_the_same_request(self):
+        # Passe stab-1 — a backend restart (cargo watch) mid-poll used to
+        # surface as a tool error and drop the agent out of the room. The
+        # bridge now retries transport failures, SAME query string (the
+        # since_sort_order makes the resume idempotent).
+        import urllib.error
+        ok = {
+            "success": True,
+            "data": {"timed_out": True, "messages": [], "latest_sort_order": 12},
+        }
+        calls = []
+
+        def flaky(method, path, body=None):
+            calls.append(path)
+            if len(calls) < 3:
+                raise urllib.error.URLError(ConnectionRefusedError(61, "refused"))
+            return ok
+
+        with mock.patch.object(self.mod, "_http", side_effect=flaky), \
+             mock.patch.object(self.mod.time, "sleep") as mock_sleep:
+            result = self.mod.call_disc_wait_for_peer({"since_sort_order": 12})
+        self.assertEqual(len(calls), 3, "two failures then success")
+        self.assertTrue(all(p == calls[0] for p in calls), "identical request each attempt")
+        self.assertTrue(result["timed_out"])
+        self.assertEqual(mock_sleep.call_count, 2, "bounded backoff between attempts")
+
+    def test_transport_retry_is_bounded_and_names_the_resume_contract(self):
+        import urllib.error
+        with mock.patch.object(
+            self.mod, "_http",
+            side_effect=urllib.error.URLError(ConnectionRefusedError(61, "refused")),
+        ) as mock_http, mock.patch.object(self.mod.time, "sleep"):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.mod.call_disc_wait_for_peer({"since_sort_order": 5})
+        self.assertEqual(mock_http.call_count, 6, "bounded — never infinite")
+        msg = str(ctx.exception)
+        self.assertIn("since_sort_order", msg, "the error must teach the resume contract")
+        self.assertIn("unreachable", msg)
+
+    def test_http_application_errors_are_never_retried(self):
+        # A 4xx/5xx is an app-level answer, not a transport cut — retrying
+        # would hammer the backend and mask real errors.
+        with mock.patch.object(
+            self.mod, "_http",
+            side_effect=RuntimeError("HTTP 404: nope"),
+        ) as mock_http, mock.patch.object(self.mod.time, "sleep") as mock_sleep:
+            with self.assertRaises(RuntimeError):
+                self.mod.call_disc_wait_for_peer({"since_sort_order": 5})
+        self.assertEqual(mock_http.call_count, 1, "no retry on HTTP errors")
+        mock_sleep.assert_not_called()
+
     def test_forwards_since_and_timeout_in_query_string(self):
         with mock.patch.object(self.mod, "_http") as mock_http:
             mock_http.return_value = {

--- a/backend/src/api/disc_introspection.rs
+++ b/backend/src/api/disc_introspection.rs
@@ -55,6 +55,9 @@ pub struct DiscussionMeta {
     /// enough to trust.
     pub msgs_since_last_summary: u32,
     pub language: String,
+    /// Long-poll pacing contract for multi-agent rooms (stab-1).
+    #[serde(default)]
+    pub poll_policy: PollBackoffPolicy,
     pub project_id: Option<String>,
 }
 
@@ -75,6 +78,29 @@ pub struct DiscussionMessageRead {
     /// a discussed image. Empty for messages with no attachments.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub attachments: Vec<MessageAttachment>,
+}
+
+/// stab-1 (Romu) — EXPLICIT long-poll pacing contract, returned by
+/// `disc_meta` and `peer-join` instead of living as an implicit convention
+/// in each agent's prompt. Agents walk `poll_backoff_seconds` while the
+/// room is silent (staying on the last value once exhausted) and reset to
+/// the first entry as soon as a peer message arrives.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct PollBackoffPolicy {
+    pub poll_backoff_seconds: Vec<u32>,
+    pub reset_on_peer_message: bool,
+    pub max_delay_seconds: u32,
+}
+
+impl Default for PollBackoffPolicy {
+    fn default() -> Self {
+        Self {
+            poll_backoff_seconds: vec![30, 30, 60, 60, 120, 120, 240, 240, 480],
+            reset_on_peer_message: true,
+            max_delay_seconds: 480,
+        }
+    }
 }
 
 /// Lean attachment descriptor surfaced to agents via `disc_get_message`. The
@@ -144,6 +170,7 @@ pub async fn disc_meta(
     let tokens_used_total: u64 = disc.messages.iter().map(|m| m.tokens_used).sum();
 
     Json(ApiResponse::ok(DiscussionMeta {
+        poll_policy: PollBackoffPolicy::default(),
         id: disc.id,
         title: disc.title,
         agent: disc.agent,
@@ -401,5 +428,19 @@ mod tests {
     fn invalid_string_errors() {
         assert!(resolve_idx("abc", 5).is_err());
         assert!(resolve_idx("", 5).is_err());
+    }
+
+    #[test]
+    fn poll_backoff_policy_contract() {
+        use super::PollBackoffPolicy;
+        // stab-1 (Romu) — the pacing sequence is a PRODUCT contract: fine
+        // early (30s), capped at 8 min, reset on peer message. Agents and
+        // bridges rely on this exact shape.
+        let p = PollBackoffPolicy::default();
+        assert_eq!(p.poll_backoff_seconds.first(), Some(&30));
+        assert_eq!(p.poll_backoff_seconds, vec![30, 30, 60, 60, 120, 120, 240, 240, 480]);
+        assert_eq!(p.max_delay_seconds, 480, "cap = last step of the sequence");
+        assert_eq!(*p.poll_backoff_seconds.last().unwrap(), p.max_delay_seconds);
+        assert!(p.reset_on_peer_message);
     }
 }

--- a/backend/src/api/disc_invite.rs
+++ b/backend/src/api/disc_invite.rs
@@ -84,6 +84,10 @@ pub struct PeerJoinResponse {
     /// The text tells them : *use disc_append to speak*, don't just
     /// reply to the user in your terminal.
     pub next_steps: String,
+    /// Long-poll pacing contract (stab-1) — walk `poll_backoff_seconds`
+    /// while the room is silent, reset on any peer message.
+    #[serde(default)]
+    pub poll_policy: crate::api::disc_introspection::PollBackoffPolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
@@ -229,6 +233,7 @@ pub async fn peer_join(
             );
 
             Ok::<_, anyhow::Error>(PeerJoinResponse {
+                poll_policy: crate::api::disc_introspection::PollBackoffPolicy::default(),
                 disc_id,
                 session_pk,
                 peer_count,

--- a/backend/src/api/disc_source.rs
+++ b/backend/src/api/disc_source.rs
@@ -198,6 +198,13 @@ pub struct DiscAppendResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub lint: Option<AppendLintSummary>,
+    /// `sort_order` of the LAST appended message (stab-1). Long-polling
+    /// callers must pass it as `since_sort_order` instead of estimating
+    /// their position — estimates drift under concurrent posters and made
+    /// agents silently skip messages. `None` when nothing was appended.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub last_sort_order: Option<i64>,
 }
 
 /// `POST /api/disc/append`
@@ -269,6 +276,7 @@ pub async fn disc_append(
 
     let mut appended = 0u32;
     let mut skipped = 0u32;
+    let mut last_sort_order: Option<i64> = None;
     // Freshly-inserted messages, federated to peers after the loop IF this is a
     // single-message (live-turn) append on a shared disc — see the F3 gate below.
     let mut inserted_msgs: Vec<DiscussionMessage> = Vec::new();
@@ -312,8 +320,11 @@ pub async fn disc_append(
         let insert_result = state.db.with_conn(move |conn| {
             crate::db::discussions::insert_message(conn, &did_insert, &msg_clone)
         }).await;
-        if let Err(e) = insert_result {
-            return Json(ApiResponse::err(format!("DB error appending message: {}", e)));
+        match insert_result {
+            Ok(sort_order) => last_sort_order = Some(sort_order),
+            Err(e) => {
+                return Json(ApiResponse::err(format!("DB error appending message: {}", e)))
+            }
         }
         inserted_msgs.push(msg);
         appended += 1;
@@ -364,6 +375,7 @@ pub async fn disc_append(
     Json(ApiResponse::ok(DiscAppendResponse {
         appended,
         skipped_as_duplicates: skipped,
+        last_sort_order,
         diverged,
         lint: lint_summary,
     }))
@@ -674,6 +686,29 @@ mod tests {
             Json(DiscAppendRequest { disc_id: "d-lint".into(), messages: msgs }),
         ).await;
         resp.0.data.expect("append succeeds")
+    }
+
+    #[tokio::test]
+    #[serial] // global anti-halluc mode cell
+    async fn append_returns_the_real_sort_order_of_the_last_message() {
+        // stab-1 — agents estimated their position (+1 per post) because the
+        // response carried no sort_order; concurrent posters made the
+        // estimate drift and long-polls silently skipped messages.
+        crate::core::anti_halluc::set_mode("off");
+        let (state, _tmp) = lint_state(false).await;
+
+        let first = append(&state, vec![agent_msg("s1", "un")]).await;
+        let a = first.last_sort_order.expect("appended → position present");
+
+        let second = append(&state, vec![agent_msg("s2", "deux"), agent_msg("s3", "trois")]).await;
+        let b = second.last_sort_order.expect("batch → position of the LAST message");
+        assert_eq!(b, a + 2, "two more rows after the first");
+
+        // Pure duplicate: nothing appended → no position (the caller keeps
+        // its previous marker).
+        let dup = append(&state, vec![agent_msg("s3", "trois")]).await;
+        assert_eq!(dup.skipped_as_duplicates, 1);
+        assert!(dup.last_sort_order.is_none());
     }
 
     #[tokio::test]

--- a/backend/src/db/discussions.rs
+++ b/backend/src/db/discussions.rs
@@ -712,7 +712,11 @@ pub fn list_shared_sync_points(conn: &Connection) -> Result<Vec<(String, i64)>> 
     Ok(out)
 }
 
-pub fn insert_message(conn: &Connection, discussion_id: &str, msg: &DiscussionMessage) -> Result<()> {
+/// Returns the `sort_order` assigned to the inserted message — callers that
+/// long-poll (`disc_wait_for_peer`) need their REAL position, not an estimate
+/// (stab-1: estimated positions drifted under concurrent posters and made
+/// agents silently skip messages).
+pub fn insert_message(conn: &Connection, discussion_id: &str, msg: &DiscussionMessage) -> Result<i64> {
     // Get the next sort_order for this discussion
     let next_order: i64 = conn.query_row(
         "SELECT COALESCE(MAX(sort_order), 0) + 1 FROM messages WHERE discussion_id = ?1",
@@ -755,7 +759,7 @@ pub fn insert_message(conn: &Connection, discussion_id: &str, msg: &DiscussionMe
     )?;
 
     update_discussion_timestamp(conn, discussion_id)?;
-    Ok(())
+    Ok(next_order)
 }
 
 /// 0.8.5 — Stamp the QP lineage on a discussion that was spawned by a

--- a/backend/src/workflows/runner.rs
+++ b/backend/src/workflows/runner.rs
@@ -440,6 +440,12 @@ pub async fn execute_run(
     // Fresh runs have no prior step_results, so this is a no-op for them.
     for prior in &run.step_results {
         ctx.set_step_output(&prior.step_name, &prior.output);
+        let prior_agent = prior.step_agent.as_ref().map(|a| format!("{a:?}"));
+        ctx.set_step_meta(
+            &prior.step_name,
+            prior_agent.as_deref(),
+            prior.step_model.as_deref(),
+        );
     }
     // 0.7.0 Phase 6 — seed durable state from the run row. On a fresh
     // run this is empty (no-op); on resume / restart-recovery it carries
@@ -1078,9 +1084,11 @@ pub async fn execute_run(
             }
         };
 
-        // Record step output for template chaining (also extracts any
-        // `---ARTIFACT:<name>---` blocks into `{{artifacts.<name>}}`).
-        ctx.set_step_output(&step.name, &outcome.result.output);
+        // Snapshot "what actually ran" onto the result row FIRST, then seed
+        // the template ctx from it — set_step_meta reads step_agent/step_model,
+        // so the order is load-bearing (Codex review: seeding before the
+        // snapshot exposed None to the next step).
+        record_step_completion(step, &mut outcome.result, &mut ctx, Some(&agents_config.model_tiers));
 
         // 0.7.0 Phase 3 — persist declared artifacts to disk so they
         // survive past the run (committable when in a worktree,
@@ -1157,15 +1165,6 @@ pub async fn execute_run(
         // the rendered message on the run-detail page. The run is
         // resumed via `resume_run` once a decision arrives.
         let paused_here = outcome.result.status == RunStatus::WaitingApproval;
-
-        // Snapshot the step's "what was actually used here" metadata
-        // onto the result row. The user can edit the workflow between
-        // runs (swap agent, retarget API plugin, change endpoint),
-        // and without this snapshot the run history would silently
-        // start describing the *current* config instead of what ran
-        // in this run. Done here so every executor path benefits, not
-        // per-executor.
-        apply_step_snapshot(step, &mut outcome.result, Some(&agents_config.model_tiers));
 
         // Emit step done event
         emit(RunEvent::StepDone { step_result: outcome.result.clone() }).await;
@@ -2285,6 +2284,23 @@ pub(crate) fn persist_declared_artifacts(
 /// Pulled out of `execute_run`'s loop so the snapshot logic is testable
 /// in isolation (the loop itself needs a full workspace + agents to
 /// drive end-to-end).
+/// Post-execution bookkeeping for one completed step: snapshot the
+/// "what actually ran" metadata onto the result row (the user can edit the
+/// workflow between runs — history must describe THIS run), THEN seed the
+/// template ctx (`steps.X.output/agent/model`) from the snapshotted result.
+/// One function so the order can't silently regress.
+pub(crate) fn record_step_completion(
+    step: &WorkflowStep,
+    result: &mut StepResult,
+    ctx: &mut TemplateContext,
+    model_tiers: Option<&crate::models::setup::ModelTiersConfig>,
+) {
+    apply_step_snapshot(step, result, model_tiers);
+    ctx.set_step_output(&step.name, &result.output);
+    let agent_name = result.step_agent.as_ref().map(|a| format!("{a:?}"));
+    ctx.set_step_meta(&step.name, agent_name.as_deref(), result.step_model.as_deref());
+}
+
 pub(crate) fn apply_step_snapshot(
     step: &WorkflowStep,
     result: &mut StepResult,
@@ -3339,6 +3355,32 @@ mod tests {
             crate::db::workflows::insert_run(conn, &run_db)?;
             Ok(())
         }).await.unwrap();
+    }
+
+    #[test]
+    fn record_step_completion_seeds_ctx_from_the_snapshot() {
+        // Codex review (stab-1 blocker): the ctx was seeded BEFORE the
+        // snapshot filled step_agent/step_model → `{{steps.X.agent}}` was
+        // None at every real run. This exercises the production helper on an
+        // Agent step with a RAW (unsnapshotted) result.
+        let mut step = fake_step("reason");
+        step.agent = AgentType::Codex;
+        step.agent_settings = Some(crate::models::AgentSettings {
+            model: Some("gpt-5.6-sol".into()), tier: None,
+            reasoning_effort: None, max_tokens: None,
+        });
+        let mut result = fake_result("reason");
+        assert!(result.step_agent.is_none(), "raw executor output has no snapshot yet");
+
+        let mut ctx = TemplateContext::new();
+        record_step_completion(&step, &mut result, &mut ctx, None);
+
+        assert_eq!(
+            ctx.render("({{steps.reason.agent}} - {{steps.reason.model}})").unwrap(),
+            "(Codex - gpt-5.6-sol)",
+            "the signature composes from the REAL run metadata"
+        );
+        assert_eq!(result.step_agent, Some(AgentType::Codex), "snapshot persisted on the row too");
     }
 
     #[tokio::test]

--- a/backend/src/workflows/template.rs
+++ b/backend/src/workflows/template.rs
@@ -40,6 +40,22 @@ impl TemplateContext {
     /// while `.data_json` preserves JSON representation (convenient for
     /// piping into an HTTP body or a downstream JSON parser). Needed for
     /// the désagentification ApiCall→ApiCall path where nothing re-parses.
+    /// stab-1 — expose the RESOLVED agent/model of a completed step
+    /// (`{{steps.X.agent}}` / `{{steps.X.model}}`). Lets a deterministic
+    /// step compose e.g. a review signature from run metadata instead of
+    /// asking the LLM to self-report (which drifts: an agent obeying a
+    /// prompt written for another engine signs with the wrong name).
+    pub fn set_step_meta(&mut self, step_name: &str, agent: Option<&str>, model: Option<&str>) {
+        if let Some(a) = agent {
+            self.values.insert(format!("steps.{}.agent", step_name), a.into());
+            self.values.insert("previous_step.agent".into(), a.into());
+        }
+        if let Some(m) = model {
+            self.values.insert(format!("steps.{}.model", step_name), m.into());
+            self.values.insert("previous_step.model".into(), m.into());
+        }
+    }
+
     pub fn set_step_output(&mut self, step_name: &str, output: &str) {
         self.values.insert(format!("steps.{}.output", step_name), output.into());
         self.values.insert("previous_step.output".into(), output.into());
@@ -945,6 +961,26 @@ mod tests {
         ctx.set_issue("Bug 500", "Server crash", "42", "https://gh/42", &["bug".into()]);
         let result = ctx.render("Fix: {{issue.title}} (#{{issue.number}})").unwrap();
         assert_eq!(result, "Fix: Bug 500 (#42)");
+    }
+
+    #[test]
+    fn step_meta_exposes_agent_and_model_for_deterministic_signatures() {
+        // stab-1 — the PR-review signature was self-reported by the LLM and
+        // drifted ("Claude Code - GPT-5" when Codex ran the step). A
+        // deterministic post step can now compose it from run metadata.
+        let mut ctx = TemplateContext::new();
+        ctx.set_step_output("reason", "…");
+        ctx.set_step_meta("reason", Some("Codex"), Some("gpt-5.6-sol"));
+        let sig = ctx
+            .render("— 🤖 Review automatique · cron Kronn ({{steps.reason.agent}} - {{steps.reason.model}})")
+            .unwrap();
+        assert_eq!(sig, "— 🤖 Review automatique · cron Kronn (Codex - gpt-5.6-sol)");
+        assert_eq!(ctx.render("{{previous_step.agent}}").unwrap(), "Codex");
+
+        // A step with no snapshot (deterministic Exec/ApiCall) sets nothing —
+        // the placeholders stay unresolved rather than lying.
+        ctx.set_step_meta("exec", None, None);
+        assert!(ctx.render("{{steps.exec.agent}}").unwrap().contains("{{steps.exec.agent}}"));
     }
 
     #[test]

--- a/docs/tech-debt/TD-20260713-graph-delegated-oauth.md
+++ b/docs/tech-debt/TD-20260713-graph-delegated-oauth.md
@@ -1,0 +1,40 @@
+# TD-20260713-graph-delegated-oauth
+
+- **ID**: TD-20260713-graph-delegated-oauth
+- **Area**: Backend / API broker / Workflows (scheduled ApiCall)
+- **Problem (fact)**: The Daily Briefing workflow (`0935b1b2…`) and 3 Quick APIs
+  (`Get Unread Emails`, `Get Today's Calendar`, `Send Teams Chat Message`)
+  reference `api_plugin_slug: "@bundle:ms-graph"` — an atomic-bundle-creation
+  SENTINEL (`backend/src/models/bundle.rs`), not a real plugin. It resolves only
+  against an artifact declared in the same bundle payload; here it never was
+  (external import, origin not attributable from this repo's history). Every
+  cron tick has failed since at least 2026-06-29. The failure webhook of that
+  workflow goes through the same broken Quick API, so the failures were silent.
+- **Why we can't fix now (constraint)**: MS Graph `/me/...` and `/chats/...`
+  endpoints require a **delegated** OAuth token. The registry's
+  `mcp-microsoft-365` entry is an MCP transport (device-code auth, no
+  `api_spec`) — not usable by ApiCall steps. Kronn's OAuth2 broker
+  (`backend/src/core/oauth2_cache.rs`) only implements client-credentials /
+  static-exchange caching; it neither acquires nor persists/rotates a delegated
+  refresh token. Rebinding the Quick APIs to the M365 MCP is NOT equivalent and
+  was explicitly rejected (Codex review, room 3f603a34 msg 153).
+- **Impact**: the Daily Briefing (and any future scheduled Graph ApiCall) cannot
+  run unattended; personal-scope Microsoft data is unreachable from
+  désagentified steps.
+- **Mitigation in place (2026-07-13)**: workflow cron DISABLED (was failing
+  silently every weekday 09:15). Manual alternative: an Agent step using the
+  M365 MCP after a device-code consent — no cron reliability promise.
+- **Suggested direction (non-binding)**:
+  1. Add an OAuth2 **authorization-code + refresh-token** flow to the broker:
+     encrypted per-config refresh token storage, renewal/rotation on expiry,
+     same envelope encryption as other secrets.
+  2. Ship a bundled `api-ms-graph` ApiSpec (mail, calendarView, chat messages)
+     usable by ApiCall steps once the delegated flow exists.
+  3. Re-point the 3 Quick APIs to the new plugin; re-enable the cron; make the
+     failure webhook use a channel that does not depend on the plugin under
+     test.
+- **Related watch item**: run `e3eb5c20…` (2026-07-12) hit `__guard_timeout__`
+  at 1591 s against a 600 s limit with ZERO step results — the guard counts
+  wall-clock across a daemon blockage/reboot and fired late. Not the same bug;
+  keep an eye on `kronn::invariant` for recurrences (runner.rs guard loop).
+- **Next step**: dedicated ticket/PR — explicitly OUT of the stab-1 scope.

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -998,7 +998,14 @@ diverged: boolean,
 /**
  * Present only for a live single Agent append whose lint had a signal.
  */
-lint?: AppendLintSummary, };
+lint?: AppendLintSummary,
+/**
+ * `sort_order` of the LAST appended message (stab-1). Long-polling
+ * callers must pass it as `since_sort_order` instead of estimating
+ * their position — estimates drift under concurrent posters and made
+ * agents silently skip messages. `None` when nothing was appended.
+ */
+last_sort_order?: number, };
 
 /**
  * Body of `POST /api/disc/create`. The triple `(source_agent,
@@ -1256,7 +1263,11 @@ summary_up_to_msg_idx: number | null,
  * last refreshed. Lets the agent gauge whether the summary is fresh
  * enough to trust.
  */
-msgs_since_last_summary: number, language: string, project_id: string | null, };
+msgs_since_last_summary: number, language: string,
+/**
+ * Long-poll pacing contract for multi-agent rooms (stab-1).
+ */
+poll_policy: PollBackoffPolicy, project_id: string | null, };
 
 /**
  * A row of `discussion_sessions` — one live (or historical)
@@ -1942,7 +1953,12 @@ recent_messages: Array<RecentMessagePreview>,
  * The text tells them : *use disc_append to speak*, don't just
  * reply to the user in your terminal.
  */
-next_steps: string, };
+next_steps: string,
+/**
+ * Long-poll pacing contract (stab-1) — walk `poll_backoff_seconds`
+ * while the room is silent, reset on any peer message.
+ */
+poll_policy: PollBackoffPolicy, };
 
 /**
  * Body of `POST /api/discussions/peer-leave`. Identifies the caller
@@ -1958,6 +1974,15 @@ export type PeerLeaveResponse = {
  * or never joined). Either way, idempotent.
  */
 left: boolean, };
+
+/**
+ * stab-1 (Romu) — EXPLICIT long-poll pacing contract, returned by
+ * `disc_meta` and `peer-join` instead of living as an implicit convention
+ * in each agent's prompt. Agents walk `poll_backoff_seconds` while the
+ * room is silent (staying on the last value once exhausted) and reset to
+ * the first entry as soon as a peer message arrives.
+ */
+export type PollBackoffPolicy = { poll_backoff_seconds: Array<number>, reset_on_peer_message: boolean, max_delay_seconds: number, };
 
 /**
  * One preserved branch on a workflow run. Mirrors `workspace::PreservedBranch`


### PR DESCRIPTION
## Summary
We continue the Kronn stabilization.

## Changes
### Multi-agent room reliability
- [x] **Bounded transport retry in the MCP bridge** — survives backend rebuild windows (6 attempts, ~42s backoff, transport errors only, idempotent resume via `since_sort_order`)
- [x] **`disc_append` returns `last_sort_order`** — agents track their real position instead of estimating it (root cause of silently skipped messages under concurrent posters)
- [x] **Explicit `PollBackoffPolicy` returned at join/meta** — 30s→8m backoff sequence as a product contract instead of an implicit convention, with reset on peer message

### Workflow templates
- [x] **`{{steps.X.agent}}` / `{{steps.X.model}}` template variables** — real run metadata exposed to deterministic steps (snapshot applied before ctx seeding via `record_step_completion`, order locked by test)
- [x] **Deterministic PR-review signature** — composed by the pipeline from run metadata, no longer self-reported by the LLM

### CI guards
- [x] **Lint: no `.unwrap()` inside `with_conn` closures** — lexer-based scan (string/comment-aware, no length cap), 7 fixtures, baseline 0