### PR TITLE
fix : quick wins - improve anti-hallu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ _« Socle clean » — the Phase-1 hardening batch from the 2026-07 full audit (
 - **The presence header tells the truth about the pacing contract.** A cold-regime agent legitimately sleeping up to the 8-min cap shows as "en veille", grey "absent" only beyond cap + margin — and the threshold is read from the server's `poll_policy` at runtime instead of a hardcoded constant. Pacing anchors run on a reception clock (`messages.received_at`, new migration) over the newest row by `sort_order` — a federated message stamped in the past still resets the ramp and renews the lease, while `timestamp` stays the author's clock for display.
 - **`{{steps.X.agent}}` / `{{steps.X.model}}` template variables resolve on real runs.** The step snapshot was applied AFTER the template context was seeded, so both variables were always empty outside tests; `record_step_completion` now orders the two in one place.
 - **CI rejects `.unwrap()` inside `with_conn` closures.** A lexer-based lint (string/raw-string/char-literal aware, no scan cap) guards the panic-poisons-the-shared-connection class at the source; its own fixtures run in CI first.
+- **Mentioning the `[src:]` grammar no longer trips the anti-hallucination lint.** Markers quoted in inline backticks (fenced blocks were already excluded) and empty markers are mentions of the syntax, not citations — extraction now skips both. Hit 4× in one live multi-agent session as a false "fabricated" verdict.
 
 ---
 

--- a/backend/src/core/anti_halluc.rs
+++ b/backend/src/core/anti_halluc.rs
@@ -644,6 +644,83 @@ fn strip_fenced_code(text: &str) -> String {
     out
 }
 
+/// Lines with more backtick runs than this keep their spans (degraded =
+/// pre-quick-win behaviour) — bounds the pairing work on adversarial input.
+const MAX_BACKTICK_RUNS_PER_LINE: usize = 64;
+
+/// Strip `inline code` spans — a marker QUOTED in backticks is the agent
+/// talking ABOUT the `[src:]` syntax, not citing (pre-tag quick win: this
+/// false-positived 4× in one live session as "fabricated"). Strictly
+/// lexical, per line (markdown inline code doesn't survive a newline): a
+/// span opens with a run of N backticks and closes at the next run of
+/// exactly N (so `` `a` `` and ``` ``a`` ``` both work); an unclosed run is
+/// kept verbatim — backticks in plain prose never eat the rest of the line.
+/// Runs are pre-scanned once per line and their count is capped, so a long
+/// hostile line can't turn the pairing into a CPU hotspot (Copilot review).
+fn strip_inline_code(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for line in text.lines() {
+        // Fast path — the overwhelmingly common case.
+        if !line.contains('`') {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        let chars: Vec<char> = line.chars().collect();
+        // One pass: every backtick run as (start, len).
+        let mut runs: Vec<(usize, usize)> = Vec::new();
+        let mut k = 0usize;
+        while k < chars.len() {
+            if chars[k] == '`' {
+                let start = k;
+                while k < chars.len() && chars[k] == '`' {
+                    k += 1;
+                }
+                runs.push((start, k - start));
+            } else {
+                k += 1;
+            }
+        }
+        if runs.len() > MAX_BACKTICK_RUNS_PER_LINE {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        // Pair each opener with the next run of EXACTLY its length; runs
+        // consumed inside a span are never reconsidered as openers.
+        let mut drop_ranges: Vec<(usize, usize)> = Vec::new(); // [start, end)
+        let mut ri = 0usize;
+        while ri < runs.len() {
+            let (start, n) = runs[ri];
+            match (ri + 1..runs.len()).find(|&j| runs[j].1 == n) {
+                Some(rj) => {
+                    let (cstart, clen) = runs[rj];
+                    drop_ranges.push((start, cstart + clen));
+                    ri = rj + 1;
+                }
+                None => ri += 1, // unclosed — kept verbatim
+            }
+        }
+        let mut i = 0usize;
+        let mut di = 0usize;
+        while i < chars.len() {
+            if di < drop_ranges.len() && i == drop_ranges[di].0 {
+                // A single space where the span was — the surrounding prose
+                // must never weld into a NEW `[src:` across the boundary
+                // (Copilot: "[s" + span + "rc: …]" would mint a citation).
+                out.push(' ');
+                i = drop_ranges[di].1;
+                di += 1;
+                continue;
+            }
+            out.push(chars[i]);
+            i += 1;
+        }
+        out.push('\n');
+    }
+    out
+}
+
 /// Split into candidate sentences on `.`, `!`, `?` and newlines. Char-based so
 /// it's UTF-8 safe (French accents, emoji). A `.`/`!`/`?` is only a boundary
 /// when it's followed by whitespace or end-of-text — so file paths (`retry.rs`),
@@ -771,10 +848,12 @@ const MAX_SOURCES_VERIFIED: usize = 50;
 const LINE_COUNT_SIZE_CAP_BYTES: u64 = 2 * 1024 * 1024;
 
 /// Extract every `[src: …]` marker from the text, skipping fenced code blocks
-/// (example code shouldn't be verified). Returns the inner content (after
-/// `src:`), trimmed. Bracket-balanced so `[src: a[0]]` reads `a[0]`.
+/// AND inline-backtick spans (example/quoted syntax shouldn't be verified),
+/// and dropping EMPTY markers — a bare `[src:]` in prose is a mention of the
+/// grammar, not a citation. Returns the inner content (after `src:`),
+/// trimmed. Bracket-balanced so `[src: a[0]]` reads `a[0]`.
 pub fn extract_source_markers(text: &str) -> Vec<String> {
-    let prose = strip_fenced_code(text);
+    let prose = strip_inline_code(&strip_fenced_code(text));
     let chars: Vec<char> = prose.chars().collect();
     let lower: Vec<char> = prose.to_ascii_lowercase().chars().collect();
     let needle: Vec<char> = "[src:".chars().collect();
@@ -786,6 +865,7 @@ pub fn extract_source_markers(text: &str) -> Vec<String> {
             let mut depth = 1i32;
             let mut j = i + needle.len();
             let mut buf = String::new();
+            let mut closed = false;
             while j < chars.len() {
                 match chars[j] {
                     '[' => {
@@ -795,6 +875,7 @@ pub fn extract_source_markers(text: &str) -> Vec<String> {
                     ']' => {
                         depth -= 1;
                         if depth == 0 {
+                            closed = true;
                             break;
                         }
                         buf.push(']');
@@ -803,7 +884,15 @@ pub fn extract_source_markers(text: &str) -> Vec<String> {
                 }
                 j += 1;
             }
-            out.push(buf.trim().to_string());
+            // Only a CLOSED marker is a citation — partially-typed prose
+            // (`[src: foo.rs:1` at end of text) must not reach verification
+            // (Copilot review on PR 119).
+            if closed {
+                let inner = buf.trim();
+                if !inner.is_empty() {
+                    out.push(inner.to_string());
+                }
+            }
             i = j + 1;
         } else {
             i += 1;
@@ -1963,6 +2052,76 @@ mod tests {
     #[test]
     fn extract_empty_when_none() {
         assert!(extract_source_markers("no markers here at all").is_empty());
+    }
+
+    // ── Pre-tag quick win — literal-mention false positives ──────────
+    // Live incident (2026-07-14 room, 4×): TALKING about the `[src:]`
+    // grammar in backticks was linted as a fabricated citation.
+
+    #[test]
+    fn extract_ignores_a_syntax_mention_in_backticks() {
+        let txt = "la citation `[src:]` est obligatoire dans la doc.";
+        assert!(extract_source_markers(txt).is_empty(), "quoted syntax is a mention, not a citation");
+    }
+
+    #[test]
+    fn extract_ignores_a_full_quoted_marker_in_inline_code() {
+        // Codex non-regression ask: literal text that LOOKS like a
+        // provenance, quoted in inline code — must extract nothing.
+        let txt = "utilise `[src: file: main.rs:10]` pour citer une ligne.";
+        assert!(extract_source_markers(txt).is_empty());
+        let double = "ou ``[src: url: https://x.com]`` en double backticks.";
+        assert!(extract_source_markers(double).is_empty());
+    }
+
+    #[test]
+    fn extract_drops_an_empty_marker_in_prose() {
+        assert!(extract_source_markers("un [src:] nu est une mention de grammaire.").is_empty());
+        assert!(extract_source_markers("avec espaces [src:   ] aussi.").is_empty());
+    }
+
+    #[test]
+    fn extract_keeps_the_real_marker_next_to_a_quoted_mention() {
+        let txt = "La grammaire `[src:]` s'applique ici [src: foo.rs:1].";
+        assert_eq!(extract_source_markers(txt), vec!["foo.rs:1"]);
+    }
+
+    #[test]
+    fn extract_survives_an_unclosed_backtick() {
+        // A lone backtick in prose must not swallow the rest of the line.
+        let txt = "un ` isolé puis une vraie citation [src: real.rs:2] ensuite.";
+        assert_eq!(extract_source_markers(txt), vec!["real.rs:2"]);
+    }
+
+    #[test]
+    fn extract_drops_an_unclosed_marker() {
+        // Copilot (PR 119): partially-typed prose must not become a
+        // citation — no closing `]` means no marker.
+        assert!(extract_source_markers("truncated at end [src: foo.rs:1").is_empty());
+        let mixed = "closed [src: a.rs:1] then truncated [src: b.rs:9";
+        assert_eq!(extract_source_markers(mixed), vec!["a.rs:1"]);
+    }
+
+    #[test]
+    fn extract_does_not_weld_prose_across_a_dropped_span() {
+        // Copilot (PR 119 round 3): "[s" + `span` + "rc: …]" must not
+        // concatenate into a fresh "[src:" once the span is removed — the
+        // span leaves a space behind.
+        let txt = "des crochets [s`et du code`rc: foo.rs:1] ne fusionnent pas.";
+        assert!(extract_source_markers(txt).is_empty());
+        let with_real = "idem [s`x`rc: nope] mais [src: ok.rs:4] reste.";
+        assert_eq!(extract_source_markers(with_real), vec!["ok.rs:4"]);
+    }
+
+    #[test]
+    fn extract_is_bounded_on_a_backtick_heavy_line() {
+        // Copilot (PR 119): > MAX_BACKTICK_RUNS_PER_LINE runs on one line
+        // skips span-stripping (degraded = pre-quick-win behaviour) instead
+        // of pairing runs — the call stays cheap and markers outside spans
+        // still extract.
+        let noise = "` x ".repeat(100); // 100 unmatched single-backtick runs
+        let txt = format!("{noise} et [src: real.rs:3] à la fin.");
+        assert_eq!(extract_source_markers(&txt), vec!["real.rs:3"]);
     }
 
     // ── Niveau 1 — line-spec parsing ──────────────────────────────────

--- a/backend/tests/anti_hallu_malformed_markers.rs
+++ b/backend/tests/anti_hallu_malformed_markers.rs
@@ -1,12 +1,15 @@
 //! Adversarial QA — DIMENSION "malformed_markers".
 //!
 //! Hammers the `[src: …]` extraction + verification path with malformed,
-//! degenerate, nested, multiplexed, fenced and over-cap markers. The contract:
+//! degenerate, nested, multiplexed, fenced and over-cap markers. The contract
+//! (tightened by the 0.8.11 pre-tag quick win — literal-mention false positives):
 //!
 //!  - extraction is bracket-balanced (`[src: a[0]]` → `a[0]`),
-//!  - fenced ```code``` markers are SKIPPED,
-//!  - empty / whitespace-only refs → `EmptyRef` (fabricated),
-//!  - an unclosed `[src: …` (no `]`) is read to end-of-text (best effort), no panic,
+//!  - fenced ```code``` markers AND `inline code` markers are SKIPPED,
+//!  - empty / whitespace-only markers are DROPPED (grammar mentions, not
+//!    citations) — a typed-but-empty ref (`[src: file:]`) still verifies
+//!    as `EmptyRef`,
+//!  - an unclosed `[src: …` (no `]`) is DROPPED (partially-typed prose), no panic,
 //!  - the verified-source list is capped (`MAX_SOURCES_VERIFIED = 50`),
 //!  - NO INPUT EVER PANICS,
 //!  - extraction/analysis is DETERMINISTIC.
@@ -48,98 +51,82 @@ fn cleanup(d: &Path) {
     let _ = std::fs::remove_dir_all(d);
 }
 
-// ── 1. Empty marker `[src:]` → one source, EmptyRef (fabricated) ───────────
+// ── 1. Empty marker `[src:]` → DROPPED (grammar mention, not a citation) ───
 
 #[test]
-fn empty_marker_extracts_one_and_is_empty_ref() {
+fn empty_marker_is_dropped_as_a_grammar_mention() {
+    // 0.8.11 quick win: a bare `[src:]` in prose is the agent talking ABOUT
+    // the grammar — it used to surface as EmptyRef/fabricated (4× live).
     let txt = "The default is X [src:].";
-    let markers = extract_source_markers(txt);
-    assert_eq!(
-        markers,
-        vec![String::new()],
-        "an empty [src:] must still extract exactly one (empty) marker"
-    );
-
-    let root = temp_project();
-    let report = analyze(txt, Some(&root));
-    // The empty marker classifies as a File with no reference → EmptyRef.
-    assert_eq!(report.sources.len(), 1, "exactly one source surfaced");
-    assert_eq!(
-        report.sources[0].status,
-        SourceStatus::EmptyRef,
-        "empty ref must be EmptyRef (fabricated), not Verified/Unchecked"
-    );
-    assert_eq!(
-        report.fabricated_count, 1,
-        "EmptyRef counts as fabricated (RED)"
-    );
-    cleanup(&root);
-}
-
-// ── 2. Whitespace-only marker `[src:   ]` → EmptyRef ───────────────────────
-
-#[test]
-fn whitespace_only_marker_is_empty_ref() {
-    let txt = "Trust me [src:    \t  ].";
-    let markers = extract_source_markers(txt);
-    assert_eq!(
-        markers,
-        vec![String::new()],
-        "whitespace-only inner content must trim to the empty string"
-    );
-
-    let root = temp_project();
-    let report = analyze(txt, Some(&root));
-    assert_eq!(report.sources.len(), 1);
-    assert_eq!(
-        report.sources[0].status,
-        SourceStatus::EmptyRef,
-        "whitespace-only ref must be EmptyRef"
-    );
-    assert_eq!(report.fabricated_count, 1);
-    cleanup(&root);
-}
-
-// ── 3. Unclosed marker `[src: file: x` (no `]`) → read to EOF, no panic ────
-
-#[test]
-fn unclosed_marker_reads_to_end_no_panic() {
-    let txt = "It lives in [src: file: src/foo.rs:1 and then we never close it";
-    let markers = extract_source_markers(txt);
-    // The extractor reads until ']' or end-of-text; with no ']' it consumes the
-    // remainder. It must NOT panic and must yield exactly one marker.
-    assert_eq!(markers.len(), 1, "unclosed marker yields one best-effort marker");
     assert!(
-        markers[0].starts_with("file: src/foo.rs:1"),
-        "unclosed marker captured the trailing text: got {:?}",
-        markers[0]
+        extract_source_markers(txt).is_empty(),
+        "an empty [src:] is a mention, not a citation"
+    );
+
+    let root = temp_project();
+    let report = analyze(txt, Some(&root));
+    assert_eq!(report.sources.len(), 0, "no source surfaced");
+    assert_eq!(report.fabricated_count, 0, "no fabrication from a mention");
+    // The EmptyRef verdict still exists for TYPED empty refs reaching
+    // verification directly.
+    assert_eq!(
+        verify_source_marker("file:", Some(&root)).status,
+        SourceStatus::EmptyRef,
+    );
+    cleanup(&root);
+}
+
+// ── 2. Whitespace-only marker `[src:   ]` → DROPPED like the empty one ─────
+
+#[test]
+fn whitespace_only_marker_is_dropped() {
+    let txt = "Trust me [src:    \t  ].";
+    assert!(
+        extract_source_markers(txt).is_empty(),
+        "whitespace-only inner content trims to empty → dropped"
+    );
+
+    let root = temp_project();
+    let report = analyze(txt, Some(&root));
+    assert_eq!(report.sources.len(), 0);
+    assert_eq!(report.fabricated_count, 0);
+    cleanup(&root);
+}
+
+// ── 3. Unclosed marker `[src: file: x` (no `]`) → DROPPED, no panic ────────
+
+#[test]
+fn unclosed_marker_is_dropped_no_panic() {
+    // 0.8.11 quick win (Copilot): partially-typed prose must not become a
+    // citation — only a marker with its closing `]` is extracted.
+    let txt = "It lives in [src: file: src/foo.rs:1 and then we never close it";
+    assert!(
+        extract_source_markers(txt).is_empty(),
+        "unclosed marker must not reach verification"
     );
 
     // Whole-pipeline must not panic on the unclosed input either.
     let root = temp_project();
     let report = analyze(txt, Some(&root));
-    assert!(report.sources.len() <= 1, "no more than the single marker");
+    assert_eq!(report.sources.len(), 0, "nothing to verify");
     cleanup(&root);
 }
 
-// ── 4. Truly unclosed empty `[src:` at the very end → no panic, empty ref ──
+// ── 4. Truly unclosed empty `[src:` at the very end → no panic, dropped ────
 
 #[test]
 fn dangling_open_marker_at_eof_no_panic() {
     let txt = "trailing open bracket [src:";
-    let markers = extract_source_markers(txt);
-    // `[src:` with nothing after → reads zero chars to EOF → empty marker.
-    assert_eq!(
-        markers,
-        vec![String::new()],
-        "dangling [src: with no body extracts a single empty marker"
+    assert!(
+        extract_source_markers(txt).is_empty(),
+        "dangling [src: with no body extracts nothing"
     );
-    // Must not panic when verified.
-    let check = verify_source_marker(&markers[0], None::<&Path>);
+    // The EmptyRef contract itself is untouched for direct verification.
+    let check = verify_source_marker("", None::<&Path>);
     assert_eq!(
         check.status,
         SourceStatus::EmptyRef,
-        "dangling empty marker verifies as EmptyRef even with no root"
+        "an empty ref still verifies as EmptyRef even with no root"
     );
 }
 
@@ -222,22 +209,26 @@ fn marker_inside_fenced_block_is_skipped() {
     cleanup(&root);
 }
 
-// ── 9. Marker inside `inline code` → single backticks are NOT a fence ──────
+// ── 9. Marker inside `inline code` → SKIPPED (0.8.11 quick win) ────────────
 
 #[test]
-fn marker_inside_inline_code_is_still_extracted() {
-    // `strip_fenced_code` only strips triple-backtick FENCES (line-level). A
-    // single-backtick inline span is NOT a fence, so the marker is extracted.
+fn marker_inside_inline_code_is_skipped() {
+    // A marker quoted in backticks is the agent showing the syntax, not
+    // citing — it false-positived as "fabricated" 4× in one live session.
     let txt = "Use this `[src: file: src/foo.rs:1]` syntax.";
-    let markers = extract_source_markers(txt);
-    assert_eq!(
-        markers,
-        vec!["file: src/foo.rs:1"],
-        "an inline-code single-backtick marker is NOT skipped (only fences are)"
+    assert!(
+        extract_source_markers(txt).is_empty(),
+        "an inline-code marker is a quoted example, never extracted"
     );
 
     let root = temp_project();
     let report = analyze(txt, Some(&root));
+    assert_eq!(report.sources.len(), 0);
+    assert_eq!(report.fabricated_count, 0);
+
+    // The same marker OUTSIDE backticks still extracts and verifies.
+    let real = "Use this [src: file: src/foo.rs:1] citation.";
+    let report = analyze(real, Some(&root));
     assert_eq!(report.sources.len(), 1);
     assert_eq!(report.sources[0].status, SourceStatus::Verified);
     cleanup(&root);


### PR DESCRIPTION
## Summary
Anti-halluc lint (`backend/src/core/anti_halluc.rs`)

## Changes
- [x] **Markers quoted in inline backticks are ignored** — new `strip_inline_code` applied after `strip_fenced_code` in `extract_source_markers`: a span opens on a run of N backticks and closes on the next run of exactly N (handles `` `…` `` and ``` ``…`` ``), an unclosed backtick is kept verbatim and can never swallow the rest of the line. Strictly lexical, per line.
- [x] **Empty markers are dropped at extraction** — a bare `[src:]` in prose is a mention of the grammar, not a citation (hit 4× live in one multi-agent session as a false "fabricated" verdict). Typed-but-empty refs (`[src: file:]`) keep their `EmptyRef` verdict — no regression on `empty_ref_variants`.
- [x] **5 non-regression tests** — `[src:]` mention in backticks ⇒ 0 markers; full quoted marker in inline code (single AND double backticks) ⇒ 0; empty marker in prose ⇒ 0; real marker NEXT TO a quoted mention ⇒ only the real one extracted; unclosed lone backtick ⇒ the real citation after it still extracted.