### PR TITLE
Fix Codex session resume, exact CLI reply routing, and agentless rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A fresh interactive Codex session now gets its Resume button. Its native id
+  reaches the bridge through neither the environment nor a `codex resume` argv,
+  so the participant stayed permanently non-resumable; the bridge now reads
+  which rollout session file the ancestor CLI itself keeps open — a fact, not an
+  inference — and accepts it only under a strict rule: exactly one open rollout,
+  a valid first-line `session_meta`, canonical UUID matching the filename,
+  `originator=codex-tui`, `source=cli`. Anything else, including a Kronn-spawned
+  `codex exec` holding its own file open, resolves to nothing rather than invent
+  provenance. The id then rides the existing idle wait — no extra round trip —
+  and fills the live session row late; the expensive probe never runs on the
+  wait path itself.
+- **Replies in multi-agent rooms now return to the exact CLI author.** Live MCP
+  messages persist their verified local CLI session separately from the
+  provider name. A `reply_to_message_id` with no explicit target therefore
+  reaches the precise `@codex-cli[-N]` or other joined session that authored the
+  message, even when several peers use the same provider. Explicit targets
+  still win, native same-provider agents are not launched by coincidence, and
+  wait/introspection responses expose the durable `reply_target`.
+
+- A discussion created without launching an agent now starts with its
+  discussion agent disabled. The creation form always sends a placeholder agent
+  for a NOT NULL column, and leaving that placeholder live meant the first
+  invited CLI produced a double answer — the native agent and the CLI both
+  replying to the same turn. The header's existing control re-enables the
+  native agent in one click.
 - The rebuilt guided tour no longer exceeds the strict ESLint warning ratchet:
   its async navigation, DOM measurement, focus handling and resume test now
   follow the React hook/compiler rules without suppressions. Frontend lint and

--- a/backend/scripts/disc-introspection-mcp.py
+++ b/backend/scripts/disc-introspection-mcp.py
@@ -122,7 +122,9 @@ TOOLS = [
             "copyable `MSG-xxxxxxxx` / full UUID (`message_id`). Negative idx "
             "counts from the end (-1 = last). Optional `before` / `after` "
             "return a bounded surrounding window (maximum 10 each). Replies "
-            "expose their durable `reply_to_message_id`. Use this "
+            "expose their durable `reply_to_message_id`; locally-authored CLI "
+            "messages also expose `reply_target`, the exact joined session to "
+            "answer without guessing from the provider name. Use this "
             "when you need verbatim local context without loading or "
             "summarising the whole discussion. Cheap."
         ),
@@ -839,7 +841,7 @@ TOOLS = [
             "Long-poll the current Kronn discussion for new messages "
             "from OTHER agents. Blocks server-side (up to 170 s) until "
             "either a new message appears (newer than `since_sort_order`, "
-            "from an agent type different from this CLI's) or the "
+            "and not authored by this exact CLI session) or the "
             "timeout fires. Cheap on tokens — replaces polling loops "
             "where the agent kept calling `disc_meta` every few "
             "seconds. Returns `{timed_out, messages, "
@@ -857,6 +859,9 @@ TOOLS = [
             "(use `reply_to_message_id` for one transcript message). Current messages carry typed "
             "`targets` that distinguish the configured discussion agent, a "
             "punctual native agent, and one exact joined CLI. A joined CLI "
+            "message also carries `reply_target` when Kronn knows its exact "
+            "author session, so a reply stays attached to that CLI even when "
+            "several peers use the same provider. A joined CLI "
             "receives User turns only when its own CLI identity is selected; "
             "unrelated prompts are omitted to save tokens. Legacy "
             "`target_agents` / `target_agent` remain compatibility projections. IMPORTANT: "
@@ -2703,13 +2708,18 @@ def _session_id_for_caller():
     return _BRIDGE_SESSION_ID
 
 
-def _native_conversation_id():
+def _native_conversation_id(allow_probe=True):
     """Return the CLI's own resume id when the runtime exposes it.
 
     This is intentionally separate from `_session_id_for_caller()`: the latter
     identifies the Kronn bridge process, while this value is what the human can
     pass to the CLI's native resume command. Unknown clients and malformed
     values degrade to `None`; Kronn never fabricates a resumable id.
+
+    `allow_probe=False` restricts resolution to the environment and to an
+    already-cached probe result. The idle wait runs on every poll and sits on
+    the critical path — it must never pay for `ps`/`lsof` walks; those belong
+    to join/resume, which happen once.
     """
     agent_type = _agent_type_for_session()
     env_name = {
@@ -2723,10 +2733,16 @@ def _native_conversation_id():
         # Codex currently exposes CODEX_THREAD_ID to the interactive shell but
         # some MCP launch paths do not forward it to the stdio server. A
         # resumed Codex process still carries the exact native id in its own
-        # `codex resume <uuid>` argv, so recover that verified value from the
-        # CLI ancestor rather than leaving the participant permanently
-        # non-resumable. Claude has no equivalent stable argv contract here.
-        return _codex_resume_id_from_ancestors() if agent_type == "Codex" else None
+        # `codex resume <uuid>` argv; a FRESH session carries nothing in argv,
+        # but keeps its rollout session file open — recover the id from that
+        # open descriptor as a last resort (KT-114). Claude has no equivalent
+        # stable contract on either path.
+        if agent_type != "Codex":
+            return None
+        if not allow_probe:
+            # Cheap path only: reuse a probe that ALREADY ran, never start one.
+            return _CODEX_FD_PROBE_CACHE["uuid"] if _CODEX_FD_PROBE_CACHE["done"] else None
+        return _codex_resume_id_from_ancestors() or _codex_id_from_open_rollouts()
     if not raw or raw != raw.strip() or len(raw) > 512 or not raw.isprintable():
         return None
     try:
@@ -2775,6 +2791,116 @@ def _codex_resume_id_from_ancestors():
             return conversation_id
         cur = _ppid_of(cur)
     return None
+
+
+# ── KT-114 — fresh Codex TUI sessions: recover the native id from open FDs ──
+#
+# A fresh interactive Codex session has neither CODEX_THREAD_ID in the bridge's
+# environment nor a `codex resume <uuid>` argv — so both recoveries above come
+# up empty and the participant stays non-resumable. But the CLI itself holds
+# its session file open for its whole life: `rollout-<ts>-<uuid>.jsonl`, whose
+# FIRST line is a `session_meta` the CLI wrote about itself. Reading which file
+# an ANCESTOR process keeps open is a fact, not an inference — verified live on
+# 2026-07-29 for both a resumed TUI and a fresh `codex exec`.
+
+_ROLLOUT_NAME_RE = re.compile(r"rollout-[0-9T:.-]+-([0-9a-f-]{36})\.jsonl$")
+# Hard cap per subprocess call: the bridge sits on the critical path of every
+# tool call, and `lsof` can hang on dead network mounts. Better no Resume
+# button than a frozen MCP.
+_FD_PROBE_TIMEOUT_SECS = 2
+_CODEX_FD_PROBE_CACHE = {"done": False, "uuid": None}
+# Discs whose backend row already carries this bridge's conversation_id, so the
+# wait loop stops repeating a value that landed.
+_CONVERSATION_ID_DELIVERED = {}
+
+
+def _open_rollout_paths_of(pid):
+    """Rollout session files `pid` holds open. Linux/WSL via /proc/<pid>/fd,
+    macOS via `lsof -p` — the same platform split `_cmdline_of` uses. Any
+    failure degrades to an empty list, never an exception."""
+    paths = []
+    fd_dir = f"/proc/{pid}/fd"
+    if os.path.isdir(fd_dir):
+        try:
+            for entry in os.listdir(fd_dir):
+                try:
+                    target = os.readlink(os.path.join(fd_dir, entry))
+                except OSError:
+                    continue
+                if _ROLLOUT_NAME_RE.search(target):
+                    paths.append(target)
+            return paths
+        except OSError:
+            return []
+    try:
+        out = subprocess.check_output(
+            ["lsof", "-p", str(pid), "-Fn"],
+            stderr=subprocess.DEVNULL, timeout=_FD_PROBE_TIMEOUT_SECS,
+        ).decode("utf-8", errors="replace")
+    except Exception:
+        return []
+    for line in out.splitlines():
+        if line.startswith("n") and _ROLLOUT_NAME_RE.search(line):
+            paths.append(line[1:])
+    return paths
+
+
+def _rollout_session_meta(path):
+    """First line of a rollout file, parsed. `None` on any malformation."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            first = fh.readline(64 * 1024)
+        payload = json.loads(first).get("payload")
+        return payload if isinstance(payload, dict) else None
+    except Exception:
+        return None
+
+
+def _codex_id_from_open_rollouts():
+    """UUID of the ONE rollout an ancestor Codex process keeps open.
+
+    Acceptance rule agreed with Codex on 2026-07-29: exactly one distinct
+    rollout across the ancestor chain, whose first line is a valid
+    `session_meta` with a canonical `session_id` matching the filename,
+    `originator == "codex-tui"` and `source == "cli"`. Anything else — zero
+    rollouts, two, a malformed first line, or a `codex_exec` run that also
+    keeps its file open — returns `None`: Kronn never invents provenance.
+    Cached per bridge process; `lsof` is too costly for every tool call.
+    """
+    if _CODEX_FD_PROBE_CACHE["done"]:
+        return _CODEX_FD_PROBE_CACHE["uuid"]
+    resolved = None
+    found = set()
+    cur = os.getppid()
+    seen = set()
+    for _ in range(24):
+        if cur is None or cur <= 1 or cur in seen:
+            break
+        seen.add(cur)
+        for path in _open_rollout_paths_of(cur):
+            match = _ROLLOUT_NAME_RE.search(path)
+            if match:
+                found.add((match.group(1), path))
+        cur = _ppid_of(cur)
+    if len({uuid_ for uuid_, _ in found}) == 1:
+        raw, path = next(iter(found))
+        meta = _rollout_session_meta(path)
+        try:
+            canonical = str(uuid.UUID(raw))
+        except (AttributeError, ValueError):
+            canonical = None
+        if (
+            canonical is not None
+            and raw.lower() == canonical
+            and isinstance(meta, dict)
+            and meta.get("session_id") == canonical
+            and meta.get("originator") == "codex-tui"
+            and meta.get("source") == "cli"
+        ):
+            resolved = canonical
+    _CODEX_FD_PROBE_CACHE["done"] = True
+    _CODEX_FD_PROBE_CACHE["uuid"] = resolved
+    return resolved
 
 
 def _parent_process_cmdline():
@@ -4410,11 +4536,21 @@ def call_disc_wait_for_peer(args):
     # (listening/reading) lands on OUR row only, never on a concurrent
     # session of the same agent type (multi-machine setups).
     params["session_id"] = _session_id_for_caller()
+    # KT-114 — late capture: a fresh Codex TUI has no native id at join time,
+    # but the FD probe can resolve it once the CLI is up. The idle loop calls
+    # this every ≤170 s anyway, so piggyback the id here instead of adding a
+    # round trip; sent until a successful wait confirms delivery, then stopped.
+    if not _CONVERSATION_ID_DELIVERED.get(disc_id):
+        late_conversation_id = _native_conversation_id(allow_probe=False)
+        if late_conversation_id:
+            params["conversation_id"] = late_conversation_id
     qs = urllib.parse.urlencode(params)
     sep = "?" if qs else ""
     # Transport-level retry (bounded): a backend restart mid-poll must not
     # surface as a tool error — the wait is idempotent on since_sort_order.
     result = _unwrap(_http_transport_retry("GET", f"/api/discussions/{disc_id}/wait{sep}{qs}"))
+    if isinstance(result, dict) and params.get("conversation_id"):
+        _CONVERSATION_ID_DELIVERED[disc_id] = True
     if isinstance(result, dict):
         if result.get("messages"):
             _stage_read_cursor(disc_id, result.get("latest_sort_order"))

--- a/backend/scripts/test_disc_introspection_mcp.py
+++ b/backend/scripts/test_disc_introspection_mcp.py
@@ -6244,5 +6244,78 @@ class DurableSessionLinkTests(unittest.TestCase):
             self.assertIsNone(self.mod._durable_session_id())
 
 
+
+
+class CodexOpenRolloutProbeTests(unittest.TestCase):
+    """KT-114 — recovering a fresh Codex TUI's native id from its open FDs.
+
+    Acceptance rule: exactly ONE distinct rollout across the ancestor chain,
+    with a valid session_meta (canonical UUID matching the filename,
+    originator=codex-tui, source=cli). Anything else returns None — Kronn
+    never invents provenance.
+    """
+
+    UUID = "019fad80-1c9a-7333-96b1-c06804f91641"
+    PATH = f"/home/user/.codex/sessions/2026/07/30/rollout-2026-07-30T06-00-00-{UUID}.jsonl"
+
+    def setUp(self):
+        self.mod = _load_module()
+        # One fake ancestor, then init.
+        mock.patch.object(self.mod.os, "getppid", return_value=100).start()
+        mock.patch.object(self.mod, "_ppid_of", side_effect=lambda pid: 1).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def _probe(self, paths_by_pid, meta):
+        with mock.patch.object(
+            self.mod, "_open_rollout_paths_of",
+            side_effect=lambda pid: paths_by_pid.get(pid, []),
+        ), mock.patch.object(
+            self.mod, "_rollout_session_meta", return_value=meta,
+        ):
+            return self.mod._codex_id_from_open_rollouts()
+
+    def _valid_meta(self, **overrides):
+        meta = {"session_id": self.UUID, "originator": "codex-tui", "source": "cli"}
+        meta.update(overrides)
+        return meta
+
+    def test_single_valid_rollout_resolves_the_canonical_uuid(self):
+        got = self._probe({100: [self.PATH]}, self._valid_meta())
+        self.assertEqual(got, self.UUID)
+
+    def test_zero_rollouts_resolve_to_none(self):
+        self.assertIsNone(self._probe({}, self._valid_meta()))
+
+    def test_two_distinct_rollouts_resolve_to_none(self):
+        other = self.PATH.replace("91641", "91642")
+        self.assertIsNone(self._probe({100: [self.PATH, other]}, self._valid_meta()))
+
+    def test_malformed_session_meta_resolves_to_none(self):
+        self.assertIsNone(self._probe({100: [self.PATH]}, None))
+
+    def test_codex_exec_originator_resolves_to_none(self):
+        # A `codex exec` run ALSO keeps its rollout open; accepting it would
+        # attach a Kronn-spawned run's id to the human's session.
+        meta = self._valid_meta(originator="codex_exec", source="exec")
+        self.assertIsNone(self._probe({100: [self.PATH]}, meta))
+
+    def test_meta_uuid_mismatch_resolves_to_none(self):
+        meta = self._valid_meta(session_id=self.UUID.replace("91641", "91642"))
+        self.assertIsNone(self._probe({100: [self.PATH]}, meta))
+
+    def test_result_is_cached_per_process(self):
+        first = self._probe({100: [self.PATH]}, self._valid_meta())
+        # Second call must not re-scan: feed it data that would now fail.
+        second = self._probe({}, None)
+        self.assertEqual(first, second)
+
+    def test_lsof_failure_degrades_to_empty_not_raise(self):
+        with mock.patch.object(
+            self.mod.subprocess, "check_output",
+            side_effect=self.mod.subprocess.TimeoutExpired(cmd="lsof", timeout=2),
+        ), mock.patch.object(self.mod.os.path, "isdir", return_value=False):
+            self.assertEqual(self.mod._open_rollout_paths_of(100), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/src/api/disc_introspection.rs
+++ b/backend/src/api/disc_introspection.rs
@@ -79,6 +79,10 @@ pub struct DiscussionMessageRead {
     pub agent_type: Option<AgentType>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reply_to_message_id: Option<String>,
+    /// Exact joined CLI identity that authored this message, when locally
+    /// verifiable. Use it as the durable target for a reply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_target: Option<MessageTarget>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub tokens_used: u64,
     /// Files attached to this message (0.8.8). Lets an agent that navigates to
@@ -464,14 +468,22 @@ pub async fn disc_get_message(
 
     let msg = &disc.messages[resolved_idx];
     let msg_id = msg.id.clone();
-    let attachments = state
+    let did_for_message_meta = id.clone();
+    let (attachments, reply_target) = state
         .db
         .with_conn(move |conn| {
-            crate::db::discussions::list_context_files_for_message(conn, &msg_id)
-                .map_err(|e| anyhow::anyhow!(e))
+            let attachments =
+                crate::db::discussions::list_context_files_for_message(conn, &msg_id)?;
+            let reply_target = crate::db::discussions::message_cli_author_target(
+                conn,
+                &did_for_message_meta,
+                &msg_id,
+            )?;
+            Ok((attachments, reply_target))
         })
         .await
-        .unwrap_or_default()
+        .unwrap_or_default();
+    let attachments = attachments
         .into_iter()
         .map(|f| MessageAttachment {
             id: f.id,
@@ -500,6 +512,7 @@ pub async fn disc_get_message(
         content: msg.content.clone(),
         agent_type: msg.agent_type.clone(),
         reply_to_message_id: msg.reply_to_message_id.clone(),
+        reply_target,
         timestamp: msg.timestamp,
         tokens_used: msg.tokens_used,
         attachments,

--- a/backend/src/api/disc_invite.rs
+++ b/backend/src/api/disc_invite.rs
@@ -734,6 +734,13 @@ pub struct WaitForPeerQuery {
     /// a stale bridge process keep a resumed sibling alive.
     #[serde(default)]
     pub session_id: Option<String>,
+    /// KT-114 — late capture of the CLI's native resume id. A fresh Codex TUI
+    /// has nothing to declare at join time; once its bridge resolves the id
+    /// (from the CLI's own open session file), the idle wait carries it here so
+    /// the Resume button appears without any extra round trip. Validated and
+    /// bounded like the join-time value; ignored without a session identity.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
@@ -772,6 +779,11 @@ pub struct WaitForPeerMessage {
     /// exact joined CLI session of the same provider.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub targets: Vec<MessageTarget>,
+    /// Exact local CLI identity that authored this message. A caller can use
+    /// it as the durable reply target without guessing from provider names.
+    /// `None` for humans, native agents, imports and revision events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_target: Option<MessageTarget>,
     /// Server-computed for the calling durable CLI session. A CLI answers only
     /// when this is true; matching the provider name is intentionally
     /// insufficient because `@codex` and `@codex · CLI` are distinct targets.
@@ -935,6 +947,11 @@ pub async fn wait_for_peer(
         let agent_touch = agent_type.clone();
         let sess_touch = caller_session_id.clone();
         let listening_ttl = timeout_secs as i64 + ACTIVITY_LISTENING_MARGIN_SECS;
+        // KT-114 — a bridge that resolved its native resume id AFTER joining
+        // delivers it on this idle loop. Same validation as the join-time
+        // value; a malformed id is dropped, never guessed at.
+        let late_conversation_id =
+            normalize_conversation_id(q.conversation_id.as_deref()).unwrap_or(None);
         if let Err(e) = state
             .db
             .with_conn(move |conn| {
@@ -944,6 +961,15 @@ pub async fn wait_for_peer(
                     &agent_touch,
                     &sess_touch,
                 )?;
+                if let Some(conversation_id) = late_conversation_id.as_deref() {
+                    crate::db::discussion_sessions::set_live_session_conversation_id(
+                        conn,
+                        &disc_id_touch,
+                        &agent_touch,
+                        &sess_touch,
+                        conversation_id,
+                    )?;
+                }
                 crate::db::discussion_sessions::set_session_activity(
                     conn,
                     &disc_id_touch,
@@ -974,7 +1000,7 @@ pub async fn wait_for_peer(
                 let mut stmt = conn.prepare(
                     "SELECT message_id, sort_order, role, agent_type, content, timestamp,
                             author_pseudo, event_type, target_message_id, target_agent,
-                            targets
+                            targets, author_agent_type, author_cli_session_id
                      FROM (
                          SELECT id AS message_id, sort_order, role, agent_type, content, timestamp,
                                 author_pseudo, NULL AS event_type,
@@ -992,7 +1018,20 @@ pub async fn wait_for_peer(
                                         WHERE mt.message_id = messages.id
                                         ORDER BY mt.position ASC
                                     ) AS ordered
-                                ) AS targets
+                                ) AS targets,
+                                (
+                                    SELECT ds.agent_type
+                                    FROM message_cli_authors mca
+                                    JOIN discussion_sessions ds
+                                      ON ds.id = mca.cli_session_id
+                                     AND ds.disc_id = messages.discussion_id
+                                    WHERE mca.message_id = messages.id
+                                ) AS author_agent_type,
+                                (
+                                    SELECT mca.cli_session_id
+                                    FROM message_cli_authors mca
+                                    WHERE mca.message_id = messages.id
+                                ) AS author_cli_session_id
                          FROM messages
                          WHERE discussion_id = ?1 AND sort_order > ?2
                          UNION ALL
@@ -1014,7 +1053,9 @@ pub async fn wait_for_peer(
                                         WHERE mt.message_id = message_revision_events.target_message_id
                                         ORDER BY mt.position ASC
                                     ) AS ordered
-                                ) AS targets
+                                ) AS targets,
+                                NULL AS author_agent_type,
+                                NULL AS author_cli_session_id
                          FROM message_revision_events
                          WHERE discussion_id = ?1 AND sort_order > ?2
                      )
@@ -1048,6 +1089,17 @@ pub async fn wait_for_peer(
                                     .collect::<Vec<_>>()
                             })
                             .unwrap_or_default();
+                        let author_agent_type = r.get::<_, Option<String>>(11)?;
+                        let author_cli_session_id = r.get::<_, Option<i64>>(12)?;
+                        let reply_target =
+                            author_agent_type.zip(author_cli_session_id).map(
+                                |(agent_type, cli_session_id)| {
+                                    MessageTarget::cli(
+                                        crate::db::discussions::parse_agent_type(&agent_type),
+                                        cli_session_id,
+                                    )
+                                },
+                            );
                         Ok(WaitForPeerMessage {
                             message_id: r.get(0)?,
                             sort_order: r.get(1)?,
@@ -1070,6 +1122,7 @@ pub async fn wait_for_peer(
                                 })
                             }),
                             targets,
+                            reply_target,
                         })
                     })?
                     .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -1087,9 +1140,26 @@ pub async fn wait_for_peer(
                     // author_pseudo, so a same-agent_type peer (another
                     // ClaudeCode instance across the wire) is NOT filtered —
                     // otherwise two ClaudeCode peers go deaf to each other.
-                    .filter(|m| match (&exclude_clone, &m.agent_type) {
-                        (Some(ex), Some(ag)) if ex == ag => m.author_pseudo.is_some(),
-                        _ => true,
+                    .filter(|message| {
+                        if let Some(session_pk) = caller_session_pk {
+                            // Exact modern callers exclude only the message
+                            // written by their own durable CLI session. A
+                            // sibling Codex CLI is a real peer even though its
+                            // provider-level agent_type is identical.
+                            return message
+                                .reply_target
+                                .as_ref()
+                                .and_then(|target| target.cli_session_id)
+                                != Some(session_pk);
+                        }
+                        // Legacy callers have no exact session identity, so
+                        // retain the historical provider-level best effort.
+                        match (&exclude_clone, &message.agent_type) {
+                            (Some(ex), Some(agent)) if ex == agent => {
+                                message.author_pseudo.is_some()
+                            }
+                            _ => true,
+                        }
                     })
                     .collect();
                 // Counted before the routing filter and after the own-append one,
@@ -2471,6 +2541,7 @@ mod tests {
                 timeout_secs: Some(3),
                 exclude_agent_type: Some("Codex".into()),
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -2496,6 +2567,7 @@ mod tests {
                 timeout_secs: Some(3),
                 exclude_agent_type: Some("ClaudeCode".into()),
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -2679,6 +2751,7 @@ mod tests {
                 timeout_secs: Some(5),
                 exclude_agent_type: None,
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -2711,6 +2784,7 @@ mod tests {
                     timeout_secs: Some(10),
                     exclude_agent_type: None,
                     session_id: None,
+                    conversation_id: None,
                 }),
             )
             .await;
@@ -2785,6 +2859,7 @@ mod tests {
                 timeout_secs: Some(5),
                 exclude_agent_type: None,
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -2835,6 +2910,7 @@ mod tests {
                 timeout_secs: Some(2),
                 exclude_agent_type: Some("ClaudeCode".to_string()),
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -2883,6 +2959,7 @@ mod tests {
                 timeout_secs: Some(1),
                 exclude_agent_type: Some("Vibe".to_string()),
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await
@@ -2911,6 +2988,7 @@ mod tests {
                 timeout_secs: Some(1),
                 exclude_agent_type: Some("Codex".to_string()),
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await
@@ -2992,6 +3070,7 @@ mod tests {
                 timeout_secs: Some(1),
                 exclude_agent_type: Some("Vibe".to_string()),
                 session_id: Some("vibe-unrelated".to_string()),
+                conversation_id: None,
             }),
         )
         .await
@@ -3018,6 +3097,7 @@ mod tests {
                 timeout_secs: Some(1),
                 exclude_agent_type: Some("Codex".to_string()),
                 session_id: Some("codex-exact".to_string()),
+                conversation_id: None,
             }),
         )
         .await
@@ -3044,6 +3124,97 @@ mod tests {
                 crate::models::AgentType::Codex,
                 codex_session,
             )],
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_peer_distinguishes_two_same_provider_cli_authors() {
+        let state = make_state_with_disc("d-wait-same-provider").await;
+        let codex_b = state
+            .db
+            .with_conn(|conn| {
+                let codex_a = crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-wait-same-provider",
+                    "Codex",
+                    Some("codex-a"),
+                    "peer",
+                )?;
+                let codex_b = crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-wait-same-provider",
+                    "Codex",
+                    Some("codex-b"),
+                    "peer",
+                )?;
+                let now = chrono::Utc::now().to_rfc3339();
+                conn.execute(
+                    "INSERT INTO messages (
+                         id, discussion_id, role, content, agent_type,
+                         timestamp, sort_order, target_agent
+                     ) VALUES (
+                         'msg-from-codex-b', 'd-wait-same-provider', 'Agent',
+                         'exact reply from B', 'Codex', ?1, 3, 'Codex'
+                     )",
+                    rusqlite::params![now],
+                )?;
+                crate::db::discussions::set_message_cli_author(conn, "msg-from-codex-b", codex_b)?;
+                crate::db::discussions::replace_message_targets(
+                    conn,
+                    "msg-from-codex-b",
+                    &[MessageTarget::cli(crate::models::AgentType::Codex, codex_a)],
+                )?;
+                Ok(codex_b)
+            })
+            .await
+            .unwrap();
+
+        let addressed = wait_for_peer(
+            State(state.clone()),
+            Path("d-wait-same-provider".to_string()),
+            Query(WaitForPeerQuery {
+                since_sort_order: Some(0),
+                timeout_secs: Some(1),
+                exclude_agent_type: Some("Codex".to_string()),
+                session_id: Some("codex-a".to_string()),
+                conversation_id: None,
+            }),
+        )
+        .await
+        .0
+        .data
+        .unwrap();
+        assert!(!addressed.timed_out);
+        assert_eq!(addressed.messages.len(), 1);
+        assert!(addressed.messages[0].addressed_to_caller);
+        assert_eq!(
+            addressed.messages[0].reply_target,
+            Some(MessageTarget::cli(crate::models::AgentType::Codex, codex_b))
+        );
+
+        let author = wait_for_peer(
+            State(state),
+            Path("d-wait-same-provider".to_string()),
+            Query(WaitForPeerQuery {
+                since_sort_order: Some(0),
+                timeout_secs: Some(1),
+                exclude_agent_type: Some("Codex".to_string()),
+                session_id: Some("codex-b".to_string()),
+                conversation_id: None,
+            }),
+        )
+        .await
+        .0
+        .data
+        .unwrap();
+        assert!(
+            author.timed_out,
+            "only the exact author session filters its own append"
+        );
+        assert!(author.messages.is_empty());
+        assert_eq!(
+            author.latest_sort_order, 3,
+            "filtering an own message still advances the durable cursor"
         );
     }
 
@@ -3099,6 +3270,7 @@ mod tests {
                     timeout_secs: Some(1),
                     exclude_agent_type: Some(agent_type.to_string()),
                     session_id: Some(session_id.to_string()),
+                    conversation_id: None,
                 }),
             )
             .await
@@ -3124,6 +3296,7 @@ mod tests {
                 timeout_secs: Some(2),
                 exclude_agent_type: None,
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -3131,6 +3304,84 @@ mod tests {
         assert!(data.timed_out);
         assert_eq!(data.messages.len(), 0);
         assert_eq!(data.latest_sort_order, 0);
+    }
+
+    // ─── KT-114 — late capture of the native resume id on the idle wait ──
+
+    #[tokio::test]
+    async fn wait_for_peer_persists_a_late_conversation_id_on_the_live_session() {
+        let state = make_state_with_disc("d-wait-late-cid").await;
+        state
+            .db
+            .with_conn(|conn| {
+                crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-wait-late-cid",
+                    "Codex",
+                    Some("codex-late"),
+                    "peer",
+                )
+            })
+            .await
+            .unwrap();
+
+        let wait = |cid: Option<&str>| {
+            let state = state.clone();
+            let cid = cid.map(str::to_string);
+            async move {
+                wait_for_peer(
+                    State(state),
+                    Path("d-wait-late-cid".to_string()),
+                    Query(WaitForPeerQuery {
+                        since_sort_order: Some(0),
+                        timeout_secs: Some(1),
+                        exclude_agent_type: Some("Codex".to_string()),
+                        session_id: Some("codex-late".to_string()),
+                        conversation_id: cid,
+                    }),
+                )
+                .await
+            }
+        };
+        let stored = |state: &AppState| {
+            let state = state.clone();
+            async move {
+                state
+                    .db
+                    .with_conn(|conn| {
+                        crate::db::discussion_sessions::list_sessions(
+                            conn,
+                            "d-wait-late-cid",
+                            false,
+                        )
+                    })
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .find(|s| s.session_id.as_deref() == Some("codex-late"))
+                    .and_then(|s| s.conversation_id)
+            }
+        };
+
+        // A fresh session joins with nothing to declare.
+        let _ = wait(None).await;
+        assert_eq!(stored(&state).await, None);
+
+        // The bridge resolves the id later and piggybacks it on the idle poll.
+        let _ = wait(Some("019fad80-1c9a-7333-96b1-c06804f91641")).await;
+        assert_eq!(
+            stored(&state).await.as_deref(),
+            Some("019fad80-1c9a-7333-96b1-c06804f91641"),
+            "the Resume button depends on this row being filled late"
+        );
+
+        // A malformed value is dropped, never stored: Kronn does not invent
+        // a resumable identity out of a corrupted parameter.
+        let _ = wait(Some("not-a-uuid")).await;
+        assert_eq!(
+            stored(&state).await.as_deref(),
+            Some("019fad80-1c9a-7333-96b1-c06804f91641"),
+        );
     }
 
     // ─── 0.8.12 PR B — presence phase 1 (server-derived activity) ────
@@ -3173,6 +3424,7 @@ mod tests {
                 timeout_secs: Some(1),
                 exclude_agent_type: Some("ClaudeCode".to_string()),
                 session_id: Some("s-act".to_string()),
+                conversation_id: None,
             }),
         )
         .await;
@@ -3274,6 +3526,7 @@ mod tests {
                 timeout_secs: Some(1),
                 exclude_agent_type: Some("ClaudeCode".to_string()),
                 session_id: None,
+                conversation_id: None,
             }),
         )
         .await;
@@ -3328,6 +3581,7 @@ mod tests {
                 timeout_secs: Some(5),
                 exclude_agent_type: Some("ClaudeCode".to_string()),
                 session_id: Some("s-act2".to_string()),
+                conversation_id: None,
             }),
         )
         .await;

--- a/backend/src/api/disc_source.rs
+++ b/backend/src/api/disc_source.rs
@@ -335,7 +335,7 @@ pub async fn disc_append(
     // turns. The compatibility `target_agent` field is projected to one native
     // target only when an older bridge did not send `targets`.
     let routing_candidate = live_agent_append && req.session_id.is_some();
-    let requested_targets = if routing_candidate && !req.messages[0].targets.is_empty() {
+    let mut requested_targets = if routing_candidate && !req.messages[0].targets.is_empty() {
         match canonical_targets(&state, &req.disc_id, req.messages[0].targets.clone(), false).await
         {
             Ok(targets) => targets,
@@ -352,6 +352,68 @@ pub async fn disc_append(
     } else {
         None
     };
+    // KT-127 — bind this live MCP append to the exact durable CLI session that
+    // authored it. Provider identity alone cannot distinguish two Codex CLIs
+    // joined to the same room. A missing/mismatched session fails closed: bulk
+    // imports and unverifiable callers never acquire local CLI provenance.
+    let author_cli_session_id = if routing_candidate {
+        match (req.messages[0].agent_type.as_ref(), req.session_id.as_ref()) {
+            (Some(agent_type), Some(session_id)) => {
+                let did = req.disc_id.clone();
+                let agent = format!("{agent_type:?}");
+                let session = session_id.clone();
+                match state
+                    .db
+                    .with_read_conn(move |conn| {
+                        Ok(crate::db::discussion_sessions::find_active_session(
+                            conn, &agent, &session,
+                        )?
+                        .filter(|row| row.disc_id == did)
+                        .map(|row| row.id))
+                    })
+                    .await
+                {
+                    Ok(session) => session,
+                    Err(error) => {
+                        return Json(ApiResponse::err(format!(
+                            "DB error resolving CLI author: {error}"
+                        )))
+                    }
+                }
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+    // An explicit typed target or legacy one-shot target always wins. With no
+    // explicit responder, replying to a CLI-authored message targets that
+    // exact session — never the provider's native agent or a sibling CLI.
+    if routing_candidate && requested_targets.is_empty() && legacy_requested_target.is_none() {
+        if let Some(reply_to_message_id) = req.messages[0].reply_to_message_id.clone() {
+            let did = req.disc_id.clone();
+            requested_targets = match state
+                .db
+                .with_read_conn(move |conn| {
+                    Ok(crate::db::discussions::message_cli_author_target(
+                        conn,
+                        &did,
+                        &reply_to_message_id,
+                    )?
+                    .into_iter()
+                    .collect())
+                })
+                .await
+            {
+                Ok(targets) => targets,
+                Err(error) => {
+                    return Json(ApiResponse::err(format!(
+                        "DB error resolving reply target: {error}"
+                    )))
+                }
+            };
+        }
+    }
     // Resolve the whole presence snapshot in one DB turn, then feed the pure
     // shared routing policy. On lookup failure we fail closed as a no-agent
     // room: this live MCP caller is already a proven peer, so duplicate native
@@ -531,14 +593,23 @@ pub async fn disc_append(
         let insert_result = state
             .db
             .with_conn(move |conn| {
-                if !typed_targets.is_empty() || !dispatch_jobs.is_empty() {
-                    let dispatches = dispatch_jobs
-                        .iter()
-                        .map(|(job_id, agent)| crate::db::discussions::UserDispatchSpec {
-                            job_id,
-                            agent_override: agent.as_ref(),
-                        })
-                        .collect::<Vec<_>>();
+                let dispatches = dispatch_jobs
+                    .iter()
+                    .map(|(job_id, agent)| crate::db::discussions::UserDispatchSpec {
+                        job_id,
+                        agent_override: agent.as_ref(),
+                    })
+                    .collect::<Vec<_>>();
+                if let Some(author_cli_session_id) = author_cli_session_id {
+                    crate::db::discussions::insert_cli_message_with_targets_and_dispatches(
+                        conn,
+                        &did_insert,
+                        &msg_clone,
+                        &typed_targets,
+                        &dispatches,
+                        author_cli_session_id,
+                    )
+                } else if !typed_targets.is_empty() || !dispatches.is_empty() {
                     crate::db::discussions::insert_message_with_targets_and_dispatches(
                         conn,
                         &did_insert,
@@ -1573,6 +1644,333 @@ mod tests {
             targets,
             vec![MessageTarget::cli(AgentType::Codex, cli_session_id)]
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reply_to_routes_to_the_exact_cli_author_across_session_resume() {
+        crate::core::anti_halluc::set_mode("off");
+        let (state, _tmp) = lint_state(false).await;
+        let (author_session, author_resume, responder_session) = state
+            .db
+            .with_conn(|conn| {
+                let author = crate::db::discussion_sessions::join_disc_session_resumable(
+                    conn,
+                    "d-lint",
+                    "Codex",
+                    "codex-author-old",
+                )?;
+                let responder = crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-lint",
+                    "Vibe",
+                    Some("vibe-responder"),
+                    "peer",
+                )?;
+                Ok((author.session_pk, author.resume_token, responder))
+            })
+            .await
+            .unwrap();
+
+        append_as(
+            &state,
+            vec![agent_msg("exact-author", "message from exact Codex CLI")],
+            Some("codex-author-old"),
+        )
+        .await;
+
+        let original_message_id =
+            state
+                .db
+                .with_conn(move |conn| {
+                    let message_id = conn.query_row(
+                        "SELECT id FROM messages WHERE source_msg_id = 'exact-author'",
+                        [],
+                        |row| row.get::<_, String>(0),
+                    )?;
+                    assert_eq!(
+                        crate::db::discussions::message_cli_author_target(
+                            conn,
+                            "d-lint",
+                            &message_id,
+                        )?,
+                        Some(MessageTarget::cli(AgentType::Codex, author_session))
+                    );
+                    let resumed = crate::db::discussion_sessions::resume_disc_session(
+                        conn,
+                        "Codex",
+                        &author_resume,
+                        "codex-author-reloaded",
+                        None,
+                    )?;
+                    assert_eq!(
+                        resumed.session_pk, author_session,
+                        "a bridge reload must preserve the durable exact author identity"
+                    );
+                    Ok(message_id)
+                })
+                .await
+                .unwrap();
+
+        let mut reply = agent_msg("exact-reply", "reply from Vibe");
+        reply.agent_type = Some(AgentType::Vibe);
+        reply.reply_to_message_id = Some(original_message_id);
+        append_as(&state, vec![reply], Some("vibe-responder")).await;
+
+        let (targets, reply_author, job) = state
+            .db
+            .with_conn(move |conn| {
+                let reply_message_id = conn.query_row(
+                    "SELECT id FROM messages WHERE source_msg_id = 'exact-reply'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )?;
+                Ok((
+                    crate::db::discussions::list_message_targets(conn, &reply_message_id)?,
+                    crate::db::discussions::message_cli_author_target(
+                        conn,
+                        "d-lint",
+                        &reply_message_id,
+                    )?,
+                    crate::db::agent_dispatch::find_active_for_discussion(conn, "d-lint")?,
+                ))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            targets,
+            vec![MessageTarget::cli(AgentType::Codex, author_session)]
+        );
+        assert_eq!(
+            reply_author,
+            Some(MessageTarget::cli(AgentType::Vibe, responder_session))
+        );
+        assert!(
+            job.is_none(),
+            "replying to a CLI must never wake a same-provider native agent"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn explicit_target_overrides_the_reply_to_cli_author() {
+        crate::core::anti_halluc::set_mode("off");
+        let (state, _tmp) = lint_state(false).await;
+        let explicit_session = state
+            .db
+            .with_conn(|conn| {
+                crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-lint",
+                    "Codex",
+                    Some("codex-original"),
+                    "peer",
+                )?;
+                crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-lint",
+                    "Vibe",
+                    Some("vibe-responder"),
+                    "peer",
+                )?;
+                crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-lint",
+                    "Codex",
+                    Some("codex-explicit"),
+                    "peer",
+                )
+            })
+            .await
+            .unwrap();
+
+        append_as(
+            &state,
+            vec![agent_msg("override-author", "original Codex CLI")],
+            Some("codex-original"),
+        )
+        .await;
+        let original_message_id = state
+            .db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT id FROM messages WHERE source_msg_id = 'override-author'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .map_err(anyhow::Error::from)
+            })
+            .await
+            .unwrap();
+
+        let mut reply = agent_msg("override-reply", "explicitly for another CLI");
+        reply.agent_type = Some(AgentType::Vibe);
+        reply.reply_to_message_id = Some(original_message_id);
+        reply.targets = vec![MessageTarget::cli(AgentType::Codex, explicit_session)];
+        append_as(&state, vec![reply], Some("vibe-responder")).await;
+
+        let targets = state
+            .db
+            .with_conn(move |conn| {
+                let reply_message_id = conn.query_row(
+                    "SELECT id FROM messages WHERE source_msg_id = 'override-reply'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )?;
+                crate::db::discussions::list_message_targets(conn, &reply_message_id)
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            targets,
+            vec![MessageTarget::cli(AgentType::Codex, explicit_session)]
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn reply_to_a_native_message_keeps_legacy_untargeted_routing() {
+        crate::core::anti_halluc::set_mode("off");
+        let (state, _tmp) = lint_state(false).await;
+        state
+            .db
+            .with_conn(|conn| {
+                crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-lint",
+                    "Vibe",
+                    Some("vibe-native-reply"),
+                    "peer",
+                )?;
+                conn.execute(
+                    "INSERT INTO messages (
+                         id, discussion_id, role, content, agent_type,
+                         timestamp, sort_order
+                     ) VALUES (
+                         'native-message', 'd-lint', 'Agent', 'native answer',
+                         'Codex', datetime('now'), 1
+                     )",
+                    [],
+                )?;
+                conn.execute(
+                    "UPDATE discussions
+                     SET next_message_seq = 2, message_count = 1
+                     WHERE id = 'd-lint'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        let mut reply = agent_msg("native-message-reply", "Vibe follows up");
+        reply.agent_type = Some(AgentType::Vibe);
+        reply.reply_to_message_id = Some("native-message".into());
+        append_as(&state, vec![reply], Some("vibe-native-reply")).await;
+
+        let targets = state
+            .db
+            .with_conn(|conn| {
+                let reply_message_id = conn.query_row(
+                    "SELECT id FROM messages
+                     WHERE source_msg_id = 'native-message-reply'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )?;
+                crate::db::discussions::list_message_targets(conn, &reply_message_id)
+            })
+            .await
+            .unwrap();
+        assert!(
+            targets.is_empty(),
+            "a native author has no exact local CLI identity to infer"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn bulk_import_reply_to_never_infers_a_local_cli_target() {
+        crate::core::anti_halluc::set_mode("off");
+        let (state, _tmp) = lint_state(false).await;
+        state
+            .db
+            .with_conn(|conn| {
+                let cli_session_id = crate::db::discussion_sessions::create_session(
+                    conn,
+                    "d-lint",
+                    "Codex",
+                    Some("codex-local-author"),
+                    "peer",
+                )?;
+                conn.execute(
+                    "INSERT INTO messages (
+                         id, discussion_id, role, content, agent_type,
+                         timestamp, sort_order
+                     ) VALUES (
+                         'local-cli-message', 'd-lint', 'Agent', 'local answer',
+                         'Codex', datetime('now'), 1
+                     )",
+                    [],
+                )?;
+                crate::db::discussions::set_message_cli_author(
+                    conn,
+                    "local-cli-message",
+                    cli_session_id,
+                )?;
+                conn.execute(
+                    "UPDATE discussions
+                     SET next_message_seq = 2, message_count = 1
+                     WHERE id = 'd-lint'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        let mut first_imported = agent_msg("bulk-reply", "historical reply");
+        first_imported.reply_to_message_id = Some("local-cli-message".into());
+        append(
+            &state,
+            vec![
+                first_imported,
+                agent_msg("bulk-follow-up", "historical follow-up"),
+            ],
+        )
+        .await;
+
+        let imported = state
+            .db
+            .with_conn(|conn| {
+                let mut statement = conn.prepare(
+                    "SELECT id, target_agent
+                     FROM messages
+                     WHERE source_msg_id IN ('bulk-reply', 'bulk-follow-up')
+                     ORDER BY sort_order",
+                )?;
+                let rows = statement
+                    .query_map([], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                let rows = rows
+                    .into_iter()
+                    .map(|(message_id, target_agent)| {
+                        let targets =
+                            crate::db::discussions::list_message_targets(conn, &message_id)?;
+                        Ok((target_agent, targets))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                Ok(rows)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(imported.len(), 2);
+        assert!(imported
+            .iter()
+            .all(|(target_agent, targets)| target_agent.is_none() && targets.is_empty()));
     }
 
     #[tokio::test]

--- a/backend/src/db/discussion_sessions.rs
+++ b/backend/src/db/discussion_sessions.rs
@@ -304,6 +304,27 @@ pub fn set_session_model(conn: &Connection, session_pk: i64, model: &str) -> Res
     Ok(())
 }
 
+/// KT-114 — late capture, keyed by the session's own identity instead of a pk
+/// the wait handler does not have. Only a live row is touched: a `left`
+/// session must not resurrect with a resume id, and rewriting an unchanged
+/// value would churn the row on every idle poll.
+pub fn set_live_session_conversation_id(
+    conn: &Connection,
+    disc_id: &str,
+    agent_type: &str,
+    session_id: &str,
+    conversation_id: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE discussion_sessions SET conversation_id = ?4
+         WHERE disc_id = ?1 AND agent_type = ?2 AND session_id = ?3
+           AND status = 'active'
+           AND (conversation_id IS NULL OR conversation_id != ?4)",
+        params![disc_id, agent_type, session_id, conversation_id],
+    )?;
+    Ok(())
+}
+
 /// Record a native CLI conversation id without changing the bridge binding.
 /// The caller validates and bounds the opaque value before writing it.
 pub fn set_session_conversation_id(

--- a/backend/src/db/discussions.rs
+++ b/backend/src/db/discussions.rs
@@ -935,9 +935,57 @@ pub fn insert_message_with_targets_and_dispatches(
     targets: &[MessageTarget],
     dispatches: &[UserDispatchSpec<'_>],
 ) -> Result<i64> {
+    insert_message_with_targets_dispatches_and_cli_author(
+        conn,
+        discussion_id,
+        msg,
+        targets,
+        dispatches,
+        None,
+    )
+}
+
+/// Persist a live CLI-authored peer turn atomically with its exact local
+/// session provenance. The provider-level `messages.agent_type` is not enough
+/// when two Codex (or ClaudeCode) CLIs are joined to the same room.
+pub fn insert_cli_message_with_targets_and_dispatches(
+    conn: &Connection,
+    discussion_id: &str,
+    msg: &DiscussionMessage,
+    targets: &[MessageTarget],
+    dispatches: &[UserDispatchSpec<'_>],
+    author_cli_session_id: i64,
+) -> Result<i64> {
+    insert_message_with_targets_dispatches_and_cli_author(
+        conn,
+        discussion_id,
+        msg,
+        targets,
+        dispatches,
+        Some(author_cli_session_id),
+    )
+}
+
+fn insert_message_with_targets_dispatches_and_cli_author(
+    conn: &Connection,
+    discussion_id: &str,
+    msg: &DiscussionMessage,
+    targets: &[MessageTarget],
+    dispatches: &[UserDispatchSpec<'_>],
+    author_cli_session_id: Option<i64>,
+) -> Result<i64> {
     let tx = conn.unchecked_transaction()?;
     let sort_order = insert_message(&tx, discussion_id, msg)?;
-    replace_message_targets(&tx, &msg.id, targets)?;
+    if let Some(cli_session_id) = author_cli_session_id {
+        set_message_cli_author(&tx, &msg.id, cli_session_id)?;
+    }
+    // An empty typed list may still carry a legacy `target_agent`
+    // compatibility projection on the freshly inserted message. Replacing it
+    // with an empty list would erase that projection. With typed targets, the
+    // plural table remains authoritative and updates the projection normally.
+    if !targets.is_empty() {
+        replace_message_targets(&tx, &msg.id, targets)?;
+    }
     if !dispatches.is_empty() {
         let empty_chain = Vec::new();
         for dispatch in dispatches {
@@ -1575,6 +1623,56 @@ pub fn list_message_targets(conn: &Connection, message_id: &str) -> Result<Vec<M
         .collect::<rusqlite::Result<Vec<_>>>()
         .map_err(anyhow::Error::from)?;
     Ok(targets)
+}
+
+/// Record which exact joined CLI session authored a live MCP message.
+///
+/// This is deliberately local provenance rather than part of the portable
+/// transcript model: imported/federated messages must never impersonate a
+/// local CLI session.
+pub fn set_message_cli_author(
+    conn: &Connection,
+    message_id: &str,
+    cli_session_id: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO message_cli_authors (message_id, cli_session_id)
+         VALUES (?1, ?2)
+         ON CONFLICT(message_id) DO UPDATE SET
+             cli_session_id = excluded.cli_session_id",
+        params![message_id, cli_session_id],
+    )?;
+    Ok(())
+}
+
+/// Resolve the durable exact CLI identity that should receive a reply to one
+/// local message. Session status is intentionally not filtered: reconnecting a
+/// CLI reuses the durable session row, and introspection must retain the author
+/// even while that peer is temporarily offline.
+pub fn message_cli_author_target(
+    conn: &Connection,
+    discussion_id: &str,
+    message_id: &str,
+) -> Result<Option<MessageTarget>> {
+    conn.query_row(
+        "SELECT ds.agent_type, mca.cli_session_id
+         FROM message_cli_authors mca
+         JOIN messages m ON m.id = mca.message_id
+         JOIN discussion_sessions ds
+           ON ds.id = mca.cli_session_id
+          AND ds.disc_id = m.discussion_id
+         WHERE mca.message_id = ?1
+           AND m.discussion_id = ?2",
+        params![message_id, discussion_id],
+        |row| {
+            Ok(MessageTarget::cli(
+                parse_agent_type(&row.get::<_, String>(0)?),
+                row.get(1)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(anyhow::Error::from)
 }
 
 /// 0.8.5 — Stamp the QP lineage on a discussion that was spawned by a

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -373,6 +373,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "099_typed_message_targets",
         include_str!("sql/099_typed_message_targets.sql"),
     ),
+    (
+        "100_message_cli_authors",
+        include_str!("sql/100_message_cli_authors.sql"),
+    ),
 ];
 
 /// Run all migrations, optionally backing up the database file first.
@@ -875,6 +879,37 @@ mod tests {
             ("agent".into(), "Codex".into(), None, 0),
             "099 must preserve 098 rows while assigning their legacy punctual-agent identity"
         );
+    }
+
+    #[test]
+    fn message_cli_authors_migration_adds_durable_exact_session_provenance() {
+        let conn = Connection::open_in_memory().unwrap();
+        run(&conn).unwrap();
+
+        let has_table: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'table' AND name = 'message_cli_authors'
+                 )",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let has_index: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'index'
+                       AND name = 'idx_message_cli_authors_session'
+                 )",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert!(has_table);
+        assert!(has_index);
     }
 
     #[test]

--- a/backend/src/db/sql/100_message_cli_authors.sql
+++ b/backend/src/db/sql/100_message_cli_authors.sql
@@ -1,0 +1,14 @@
+-- Preserve the exact joined CLI session that authored a live MCP message.
+--
+-- `messages.agent_type` identifies only the provider (Codex, ClaudeCode, ...).
+-- It cannot distinguish two joined CLIs of the same provider, so a reply_to
+-- needs this local provenance to route back to the exact author session.
+CREATE TABLE message_cli_authors (
+    message_id TEXT PRIMARY KEY
+        REFERENCES messages(id) ON DELETE CASCADE,
+    cli_session_id INTEGER NOT NULL
+        REFERENCES discussion_sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_message_cli_authors_session
+    ON message_cli_authors(cli_session_id, message_id);

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -9728,6 +9728,47 @@ mod cold_api_handlers_tests {
     }
 
     #[tokio::test]
+    async fn disc_get_message_exposes_the_exact_cli_reply_target() {
+        let state = test_state();
+        let disc_id = seed_disc_with_messages(&state, 1).await;
+        let did = disc_id.clone();
+        let cli_session_id = state
+            .db
+            .with_conn(move |conn| {
+                let message_id = conn.query_row(
+                    "SELECT id FROM messages
+                     WHERE discussion_id = ?1
+                     ORDER BY sort_order ASC
+                     LIMIT 1",
+                    [&did],
+                    |row| row.get::<_, String>(0),
+                )?;
+                let cli_session_id = kronn::db::discussion_sessions::create_session(
+                    conn,
+                    &did,
+                    "Codex",
+                    Some("codex-introspection"),
+                    "peer",
+                )?;
+                kronn::db::discussions::set_message_cli_author(conn, &message_id, cli_session_id)?;
+                Ok(cli_session_id)
+            })
+            .await
+            .unwrap();
+        let app = build_router_with_auth(state, false);
+
+        let (status, json) = get_json(app, &format!("/api/discussions/{disc_id}/message/0")).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["data"]["reply_target"]["kind"], "cli");
+        assert_eq!(json["data"]["reply_target"]["agent_type"], "Codex");
+        assert_eq!(
+            json["data"]["reply_target"]["cli_session_id"],
+            cli_session_id
+        );
+    }
+
+    #[tokio::test]
     async fn disc_get_message_negative_index_resolves_last() {
         let state = test_state();
         let disc_id = seed_disc_with_messages(&state, 3).await;

--- a/docs/architecture/discussion-agent-routing.md
+++ b/docs/architecture/discussion-agent-routing.md
@@ -105,6 +105,25 @@ appends without a live JOIN session never start a runner.
 [src: file: backend/src/db/discussions.rs]
 [src: file: backend/src/api/disc_invite.rs]
 
+Every verified live MCP append also records its exact author session in
+`message_cli_authors`. This is local routing provenance, not portable transcript
+data: imports and federated messages never acquire a local CLI identity. When a
+later live peer uses `reply_to_message_id` without an explicit target, Kronn
+routes the reply to that exact author session. Explicit typed or legacy targets
+still win. This lets two Codex CLIs answer one another without waking the native
+Codex agent or filtering the sibling as “self”; only the author session excludes
+its own append. An untargeted message from the native Codex agent remains a real
+peer turn for a Codex CLI — provider equality alone is never treated as
+self-authorship. Messages written before this provenance existed may be replayed
+once when an old cursor is restored because Kronn cannot safely guess which
+historical CLI wrote them. `disc_wait_for_peer` and `disc_get_message` expose
+the identity as `reply_target` so agents can inspect the decision without
+loading session tables.
+[src: file: backend/src/db/sql/100_message_cli_authors.sql]
+[src: file: backend/src/api/disc_source.rs]
+[src: file: backend/src/api/disc_invite.rs]
+[src: file: backend/src/api/disc_introspection.rs]
+
 An untargeted live peer append in a native discussion deliberately addresses
 the native principal: this is how an invited CLI hands work back to the
 discussion's normal agent. Peer-to-peer exchanges that must exclude that
@@ -115,6 +134,8 @@ principal use a structured target; autonomous rooms use no-agent mode.
 
 - `message_targets` records every intended addressee kind, agent type and
   optional exact CLI session in order.
+- `message_cli_authors` records the exact local CLI author for verified live MCP
+  appends, enabling deterministic `reply_to` routing across same-provider peers.
 - `messages.target_agent` remains the first-target compatibility projection.
 - `agent_dispatch_jobs.agent_override_json` records the native one-shot for
   one target. Dedupe keys include the message (or revision) and target agent.

--- a/docs/operations/mcp-servers/kronn-internal.md
+++ b/docs/operations/mcp-servers/kronn-internal.md
@@ -203,8 +203,12 @@ movement is no longer silent or indistinguishable from transport loss.
 Every delivered item also carries a durable `message_id`. The bridge echoes the
 batch as `delivered_message_ids` and tells the caller to acknowledge those exact
 ids; a reply to one transcript message should pass that id as
-`reply_to_message_id`. Revision events use their own durable event id and retain
-the revised transcript id separately in `target_message_id`.
+`reply_to_message_id`. A locally-authored CLI message additionally carries
+`reply_target`, the exact joined session that authored it. With no explicit
+mention/target, `disc_append` routes the reply to that identity automatically;
+an explicit target still takes precedence. Revision events use their own
+durable event id and retain the revised transcript id separately in
+`target_message_id`.
 [src: file: backend/scripts/disc-introspection-mcp.py]
 [src: file: backend/scripts/test_disc_introspection_mcp.py]
 [src: file: backend/src/api/disc_invite.rs]
@@ -212,14 +216,15 @@ the revised transcript id separately in `target_message_id`.
 Human turns use typed identities. `discussion_agent` means the configured
 native agent, `agent` means a punctual native invocation, and `cli` means one
 exact joined session. Provider equality is not ownership: a joined Codex CLI
-must not answer a turn addressed to punctual Codex. Current bridges send their
-durable session id, and the wait endpoint omits unrelated User prompts entirely
-to avoid consuming context tokens; its cursor still advances past those hidden
-turns.
+must not answer a turn addressed to punctual Codex, but it still observes an
+untargeted Agent turn authored by native Codex because that is a different
+identity. Current bridges send their durable session id, and the wait endpoint
+omits unrelated User prompts entirely to avoid consuming context tokens; its
+cursor still advances past those hidden turns.
 
 ## disc_append — two modes
 
-- **Simple (recommended for live chat)** : `disc_append({content: "..."})`. Bridge auto-fills `disc_id` (from `disc_join` binding), generates `source_msg_id`, defaults `role=Agent`, stamps `agent_type` from `clientInfo`, and resolves ordered mentions to typed targets. Canonical `@codex` / `@claude` aliases mean native identities; `@codex-cli`, `@codex-cli-2`, … mean exact joined sessions and are never interchangeable with the native alias. Pass the optional opaque `reply_to_message_id` to create a durable reply to a message in the same discussion.
+- **Simple (recommended for live chat)** : `disc_append({content: "..."})`. Bridge auto-fills `disc_id` (from `disc_join` binding), generates `source_msg_id`, defaults `role=Agent`, stamps `agent_type` from `clientInfo`, and resolves ordered mentions to typed targets. Canonical `@codex` / `@claude` aliases mean native identities; `@codex-cli`, `@codex-cli-2`, … mean exact joined sessions and are never interchangeable with the native alias. Pass the optional opaque `reply_to_message_id` to create a durable reply to a message in the same discussion. Unless the append also carries an explicit target, Kronn sends that reply to the exact local CLI author recorded on the referenced message.
 - Mentions inside inline/fenced code are documentation and never dispatch. Use
   code formatting whenever you need to discuss an alias without invoking it.
 - **Bulk (transcript import)** : `disc_append({disc_id, messages: [{source_msg_id, role, content, agent_type}, …]})`. Idempotent on `(disc_id, source_msg_id)`.

--- a/frontend/src/pages/DiscussionsPage.tsx
+++ b/frontend/src/pages/DiscussionsPage.tsx
@@ -1476,6 +1476,11 @@ export function DiscussionsPage({
         workspace_mode: config.workspaceMode === 'Isolated' ? 'Isolated' : undefined,
         base_branch: config.workspaceMode === 'Isolated' ? config.baseBranch : undefined,
         tier: config.tier !== 'default' ? config.tier : undefined,
+        // A disc created as a waiting room for invited peers must not keep a
+        // live discussion agent. The `agent` above is only a placeholder for a
+        // NOT NULL column — left active, the first invited CLI produced a
+        // DOUBLE answer (native + CLI). The header re-enables it in one click.
+        no_agent: config.launchAgentNow ? undefined : true,
       });
     } catch (e) {
       toast(userError(e), 'error');

--- a/frontend/src/pages/__tests__/DiscussionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DiscussionsPage.test.tsx
@@ -2005,6 +2005,9 @@ describe('DiscussionsPage', () => {
     const createCall = vi.mocked(discussionsApi.create).mock.calls[0][0];
     expect(createCall.title).toBe('RGPD room for later');
     expect(createCall.agent).toBe('ClaudeCode');
+    // KT-128 — the placeholder agent must arrive DISABLED: left active, the
+    // first invited CLI made both it and the CLI answer the same turn.
+    expect(createCall.no_agent).toBe(true);
 
     // No agent run was kicked off — disc-first promise. The
     // assertion runs after waitFor so the handler had time to

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -1380,7 +1380,12 @@ export type DiscussionMessageRead = { idx: number, id: string,
 /**
  * Stable compact reference accepted by `disc_get_message`.
  */
-message_ref: string, role: MessageRole, content: string, agent_type: AgentType | null, reply_to_message_id?: string | null, timestamp: string, tokens_used: number,
+message_ref: string, role: MessageRole, content: string, agent_type: AgentType | null, reply_to_message_id?: string | null,
+/**
+ * Exact joined CLI identity that authored this message, when locally
+ * verifiable. Use it as the durable target for a reply.
+ */
+reply_target?: MessageTarget | null, timestamp: string, tokens_used: number,
 /**
  * Files attached to this message (0.8.8). Lets an agent that navigates to
  * an old message see what was uploaded with it instead of being blind to
@@ -3696,6 +3701,12 @@ target_agents?: Array<string>,
  * exact joined CLI session of the same provider.
  */
 targets?: Array<MessageTarget>,
+/**
+ * Exact local CLI identity that authored this message. A caller can use
+ * it as the durable reply target without guessing from provider names.
+ * `None` for humans, native agents, imports and revision events.
+ */
+reply_target?: MessageTarget | null,
 /**
  * Server-computed for the calling durable CLI session. A CLI answers only
  * when this is true; matching the provider name is intentionally


### PR DESCRIPTION
## Summary
Optimize Resume btn for codex session, discussion without any agents, 

## Changes
  - [x] Restore the Resume action for fresh interactive Codex sessions
  - [x] Securely resolve the native Codex conversation UUID from the CLI’s open rollout file
  - [x] Persist exact CLI author provenance on live discussion messages
  - [x] Route message replies to the exact joined CLI session, including multiple CLIs using the same provider
  - [x] Keep explicit reply targets authoritative and prevent accidental native-agent dispatch
  - [x] Keep bulk transcript imports untargeted and free of local CLI provenance
  - [x] Expose durable reply targets through the Kronn MCP discussion tools
  - [x] Start discussions created without an agent with the native discussion agent disabled
  - [x] Prevent duplicate native-agent and invited-CLI responses in agentless rooms
  - [x] Add the required database migration and generated TypeScript bindings
  - [x] Update the discussion-routing architecture, MCP documentation, and 0.9.2 changelog
  - [x] Add regression coverage for session discovery, exact reply routing, imports, and agentless creation